### PR TITLE
Add CLAUDE.md and expose repo skills to Claude Code

### DIFF
--- a/.claude/skills/react-testing-library
+++ b/.claude/skills/react-testing-library
@@ -1,0 +1,1 @@
+../../.agents/skills/react-testing-library

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,4 +142,3 @@ npm run lint -- src/pages/Login.js  # Lint specific file
 - Tests are expected. Most non-trivial code must be accompanied by appropriate unit tests. Tests should be meaningful, readable, and cover the main execution paths and edge cases.
 - Consistency matters. Follow existing project conventions, naming standards, and architectural patterns.
 - Fail explicitly. Handle errors clearly and predictably; avoid silent failures or ambiguous behavior.
-- TypeScript over JavaScript. Prefer TypeScript instead of JavaScript. Use strict typing, explicit interfaces, and meaningful types to improve correctness and maintainability.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+didibudget is a money-management SPA (track expenses, monthly balances, savings/investments). It is the **frontend only** and talks to a separate GraphQL backend (https://github.com/didaquis/didibudget-backend) via Apollo Client. The backend must be running for the app to function.
+
+Stack: React 18, React Router 6, Apollo Client 3, Reactstrap (Bootstrap 5), Recharts. Build/dev with Vite; tests with Vitest + React Testing Library.
+
+`AGENTS.md` contains a longer Copilot-oriented walkthrough — consult it for additional detail. The codebase is plain JavaScript.
+
+## Commands
+
+```bash
+npm run dev                  # Vite dev server (http://localhost:5173)
+npm run build                # Production bundle → ./dist/
+npm run lint                 # ESLint over ./src
+npm run lint -- --fix        # Auto-fix lint violations
+npm run test                 # Run all tests once
+npm run test:watch           # Tests in watch mode
+npm run test -- utils        # Run tests matching a pattern (e.g. filename substring)
+npm run test -- --coverage   # With coverage report
+```
+
+Requires Node 24.14 (see `.nvmrc`). Copy `_env` to `.env` and set `VITE_PROTOCOL`, `VITE_HOST`, `VITE_PORT`, `VITE_GRAPHQL` before running.
+
+## Conventions (enforced by ESLint)
+
+- **No semicolons**, **single quotes**, `curly` required, `no-return-await`.
+- Indentation is **tabs**.
+- Custom rule `no-lenght/no-lenght` catches the common `.lenght` typo (should be `.length`) — it errors the build.
+- Source files are `.js` but **contain JSX**; Vite's esbuild is configured to load `src/**/*.js` as JSX (`vite.config.js`). Do not rename to `.jsx`.
+
+## Architecture
+
+- **Entry**: `src/index.js` mounts `<App>` wrapped in `AuthContext` Provider and Apollo Provider. `src/App.js` defines all routes.
+- **Auth** (`src/AuthContext.js`): global `isAuth` / `userData` state. `userData` is decoded from the JWT (`jsonwebtoken`) and holds email, isAdmin, isActive, registrationDate, uuid. Tokens + user data live in **sessionStorage** via `src/utils/session.js`, so auth survives page reloads.
+- **Apollo** (`src/apollo/config.js`): a link chain — `authMiddleware` (attaches `Bearer <token>` from session) → `errorLink` (on `UNAUTHENTICATED`/`FORBIDDEN` graphQL errors or `invalid_token` network errors, clears session and hard-redirects to `/`; rewrites `INTERNAL_SERVER_ERROR` messages) → `httpLink`. Changing this affects every API call.
+- **Routing** (`src/App.js`): React Router 6. Pages are lazy-loaded behind a `<Suspense>` spinner. Routes are guarded by wrapper components `RequireAuth`, `RequireUnauthenticated`, and `RequireAdminRole` (admin routes nest `RequireAdminRole` inside `RequireAuth`).
+- **GraphQL** (`src/gql/`): `queries/` and `mutations/` split by entity (expenses, users, monthlyBalances, expenseCategories, auth). Operations are named exports (e.g. `LIST_ALL_EXPENSES`).
+- **Data-fetching components**: under `src/components/<Entity>/`, files named `Get*.js` (e.g. `GetListOfExpensesWithPagination.js`) wrap a `useQuery`/`useMutation` and handle loading/error, keeping fetching separate from presentation. Standard pattern: `if (loading) return <Spinner />; if (error) return <ErrorAlert error={error} />`.
+- **pages/** are route-level screens; **components/** are reusable UI (each usually an `index.js`, often with a colocated `index.test.js`).
+
+## Testing notes
+
+- Test files are colocated with the `.test.js` suffix; environment is `jsdom` with globals enabled and `TZ=Europe/Madrid` (set in `vite.config.js`) — relevant for date-sensitive tests.
+- Setup file `vitest.setup.js` pulls in `@testing-library/jest-dom` matchers.
+
+## Files to change with care
+
+`vite.config.js` (build + test env), `src/apollo/config.js` (auth/error middleware, all API calls), `src/AuthContext.js` (global auth + routing guards).


### PR DESCRIPTION
### **User description**
## Summary

Onboards Claude Code to this repository:

- **Add `CLAUDE.md`** — concise, verified guidance for Claude Code: commands, ESLint conventions (no semicolons, tabs, `no-lenght` rule, `.js`-contains-JSX gotcha), and architecture (Apollo link chain, sessionStorage auth, guarded lazy routes, `Get*.js` data-fetching pattern).
- **Drop the "TypeScript over JavaScript" guideline from `AGENTS.md`** — it contradicted this repo, which is plain JavaScript.
- **Expose `.agents/skills/` to Claude Code** via a per-skill symlink under `.claude/skills/`. Claude Code only auto-discovers skills from `.claude/skills/`; the symlink keeps a single source of truth (`.agents/skills/`, managed by `skills-lock.json`) with no duplication. Git stores it as a real symlink (mode `120000`).

## Notes

- After pulling, Claude Code must be **restarted** to start watching the newly created `.claude/skills/` directory.
- Symlinks require `core.symlinks=true` on Windows checkouts (default in Git for Windows).

## Testing

- `npm run lint` + `npm run test` (143 tests) pass via the pre-commit hook.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add CLAUDE.md for Claude Code guidance

- Expose .agents/skills to Claude Code

- Remove TypeScript guideline from AGENTS.md


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[CLAUDE.md] -->|guidance|> B[Claude Code]
  C[.agents/skills] -->|symlink|> D[.claude/skills]
  E[AGENTS.md] -->|update|> F[guidelines]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>react-testing-library</strong><dd><code>Symlink creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.claude/skills/react-testing-library

- Create symlink to .agents/skills/react-testing-library


</details>


  </td>
  <td><a href="https://github.com/didaquis/didibudget-frontend/pull/205/files#diff-1723d82dab3b9a87d29b17c89721e1fd4f409874a2e17c4fc09229a0b8bba22a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Guideline updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

- Remove TypeScript guideline
- Update existing guidelines


</details>


  </td>
  <td><a href="https://github.com/didaquis/didibudget-frontend/pull/205/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>CLAUDE.md addition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>Add guidance for Claude Code<br> <li> Include project overview<br> <li> Describe commands and conventions<br> <li> Outline architecture and testing notes</ul>


</details>


  </td>
  <td><a href="https://github.com/didaquis/didibudget-frontend/pull/205/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+52/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

