### PR TITLE
Update vendors and remove eslint-plugin-no-lenght

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,6 @@ Requires Node 24.14 (see `.nvmrc`). Copy `_env` to `.env` and set `VITE_PROTOCOL
 
 - **No semicolons**, **single quotes**, `curly` required, `no-return-await`.
 - Indentation is **tabs**.
-- Custom rule `no-lenght/no-lenght` catches the common `.lenght` typo (should be `.length`) — it errors the build.
 - Source files are `.js` but **contain JSX**; Vite's esbuild is configured to load `src/**/*.js` as JSX (`vite.config.js`). Do not rename to `.jsx`.
 
 ## Architecture

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "@vitejs/plugin-react": "6.0.3",
         "@vitest/coverage-v8": "4.1.10",
         "eslint-config-react-app": "7.0.1",
-        "eslint-plugin-no-lenght": "1.0.2-0",
         "husky": "9.1.7",
         "jsdom": "26.1.0",
         "vite": "8.1.5",
@@ -5994,13 +5993,6 @@
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
-    },
-    "node_modules/eslint-plugin-no-lenght": {
-      "version": "1.0.2-0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-no-lenght/-/eslint-plugin-no-lenght-1.0.2-0.tgz",
-      "integrity": "sha512-k3GVXpHr1VHmYw88WXsAXiMJ9pIhShcL4xqFHEKPZEZCeXVZudBPUk6flb1RXN/gYVjinDiWcIdDVXNsKBzHWQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "didibudget-frontend",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "didibudget-frontend",
-      "version": "1.16.2",
+      "version": "1.17.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "3.14.1",
         "bootstrap": "5.1.3",
-        "graphql": "16.14.0",
-        "graphql-tag": "2.12.6",
+        "graphql": "16.14.2",
+        "graphql-tag": "2.12.7",
         "jwt-decode": "4.0.0",
         "moment": "2.30.1",
         "prop-types": "15.8.1",
@@ -6692,18 +6692,18 @@
       "license": "MIT"
     },
     "node_modules/graphql": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
-      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/graphql-tag": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
-      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.7.tgz",
+      "integrity": "sha512-xnE/NFzy+0eIesvAsREJZ284zTl/wYuBAvpsFSDhRGRdRHdnE90M21Q3xAWyYInb0J756c6x0pIQ62+vtvOs1Q==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -6712,7 +6712,7 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/has-bigints": {
@@ -11113,22 +11113,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "didibudget-frontend",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "didibudget-frontend",
   "private": true,
   "type": "module",
@@ -10,8 +10,8 @@
   "dependencies": {
     "@apollo/client": "3.14.1",
     "bootstrap": "5.1.3",
-    "graphql": "16.14.0",
-    "graphql-tag": "2.12.6",
+    "graphql": "16.14.2",
+    "graphql-tag": "2.12.7",
     "jwt-decode": "4.0.0",
     "moment": "2.30.1",
     "prop-types": "15.8.1",

--- a/package.json
+++ b/package.json
@@ -46,14 +46,10 @@
   "license": "MIT",
   "eslintConfig": {
     "extends": "react-app",
-    "plugins": [
-      "no-lenght"
-    ],
     "globals": {
       "vi": "readonly"
     },
     "rules": {
-      "no-lenght/no-lenght": "error",
       "semi": [
         "warn",
         "never"
@@ -84,7 +80,6 @@
     "@vitejs/plugin-react": "6.0.3",
     "@vitest/coverage-v8": "4.1.10",
     "eslint-config-react-app": "7.0.1",
-    "eslint-plugin-no-lenght": "1.0.2-0",
     "husky": "9.1.7",
     "jsdom": "26.1.0",
     "vite": "8.1.5",


### PR DESCRIPTION
## What changed

- Bumped a few dependencies: `graphql` 16.14.0 → 16.14.2, `graphql-tag` 2.12.6 → 2.12.7 (and app version 1.16.2 → 1.17.0).
- Removed the `eslint-plugin-no-lenght` dev dependency and its ESLint config entries (`plugins` + `no-lenght/no-lenght` rule), plus the corresponding note in `CLAUDE.md`.

## Why

The `no-lenght` plugin (a guard against the `.lenght` typo) is no longer wanted in the toolchain, so it has been dropped entirely along with routine vendor updates.

## Notes for reviewers

- Removing the plugin means the `.lenght` typo is no longer caught at lint time. No such typo exists in the current codebase.
- Verified locally: `npm run lint` passes clean and the full test suite passes (146 tests, 24 files). The husky pre-commit hook also ran lint + tests on commit.