### PR TITLE
Add expense search page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,11 @@ majority to weigh against a desktop minority — it is where the app is used.
   suite says nothing about whether a value wraps mid-word, whether a control is reachable with a
   thumb, or whether a table needs sideways dragging.
 
+## UI
+
+The page is dark but form controls are **not**: the app uses default Bootstrap `form-control` /
+`form-select` with no colour overrides. Match that in new forms.
+
 ## Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,17 @@ Stack: React 18, React Router 6, Apollo Client 3, Reactstrap (Bootstrap 5), Rech
 
 `AGENTS.md` contains a longer Copilot-oriented walkthrough — consult it for additional detail. The codebase is plain JavaScript.
 
+## Target viewport: 390px
+
+The app is used almost exclusively on a **390px-wide phone viewport** (iPhone 14). This is not a
+majority to weigh against a desktop minority — it is where the app is used.
+
+- Design and verify UI changes at 390px, not as an afterthought at the end.
+- When mobile comfort conflicts with desktop convention or visual consistency, mobile wins.
+- **Check new screens at that width in a real browser before calling them done.** A passing test
+  suite says nothing about whether a value wraps mid-word, whether a control is reachable with a
+  thumb, or whether a table needs sideways dragging.
+
 ## Commands
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "5.17.0",
         "@testing-library/react": "14.3.1",
+        "@testing-library/user-event": "^14.6.1",
         "@vitejs/plugin-react": "6.0.3",
         "@vitest/coverage-v8": "4.1.10",
         "eslint-config-react-app": "7.0.1",
@@ -3090,6 +3091,20 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "14.3.1",
+    "@testing-library/user-event": "14.6.1",
     "@vitejs/plugin-react": "6.0.3",
     "@vitest/coverage-v8": "4.1.10",
     "eslint-config-react-app": "7.0.1",

--- a/src/App.js
+++ b/src/App.js
@@ -27,6 +27,7 @@ const ExpenseAdministration = lazy(() => import('./pages/Expenses/ExpenseAdminis
 const ExpenseAnalysis = lazy(() => import('./pages/Expenses/ExpenseAnalysis'))
 const YearlyExpenseOverview = lazy(() => import('./pages/Expenses/YearlyExpenseOverview'))
 const MonthlyExpenseOverview = lazy(() => import('./pages/Expenses/MonthlyExpenseOverview'))
+const SearchExpenses = lazy(() => import('./pages/Expenses/SearchExpenses'))
 
 
 export const App = () => {
@@ -111,6 +112,11 @@ export const App = () => {
 									<Route path='/yearly-expense-overview' element={
 										<RequireAuth>
 											<YearlyExpenseOverview />
+										</RequireAuth>
+									} />
+									<Route path='/search-expenses' element={
+										<RequireAuth>
+											<SearchExpenses />
 										</RequireAuth>
 									} />
 									<Route path='/logout' element={

--- a/src/components/DateSelector/index.js
+++ b/src/components/DateSelector/index.js
@@ -1,19 +1,11 @@
 import { useState, useEffect } from 'react'
 
-import Moment from 'moment'
-import momentLocalizer from 'react-widgets-moment'
-
 import { Calendar } from 'react-widgets'
 import 'react-widgets/dist/css/react-widgets.css'
 
-export const DateSelector = ({ onChange }) => {
-	Moment.locale('en', {
-		week : {
-			dow : 1, // Monday is the first day of the week.
-		}
-	})
-	momentLocalizer()
+import '../../utils/dateLocalizer'
 
+export const DateSelector = ({ onChange }) => {
 	const [date, setDate] = useState(new Date())
 
 	useEffect(() => {

--- a/src/components/Expenses/GetSearchExpenses.js
+++ b/src/components/Expenses/GetSearchExpenses.js
@@ -1,0 +1,51 @@
+import { Fragment, useState } from 'react'
+import { useQuery, useLazyQuery } from '@apollo/client'
+
+import { Spinner } from '../Spinner'
+import { ErrorAlert } from '../ErrorAlert'
+import { SearchExpensesFilters } from './SearchExpensesFilters'
+import { SearchExpensesResults } from './SearchExpensesResults'
+import { buildSearchVariables } from './SearchExpensesFilters/utils'
+
+import { LIST_EXPENSE_CATEGORIES } from '../../gql/queries/expenseCategories'
+import { SEARCH_EXPENSES } from '../../gql/queries/expenses'
+
+const PAGE_SIZE = 25
+const FIRST_PAGE = 1
+
+export const GetSearchExpenses = () => {
+	const [filters, setFilters] = useState(null)
+
+	const categoriesQuery = useQuery(LIST_EXPENSE_CATEGORIES, { fetchPolicy: 'no-cache' })
+	const [searchExpenses, searchQuery] = useLazyQuery(SEARCH_EXPENSES, { fetchPolicy: 'no-cache', notifyOnNetworkStatusChange: true })
+
+	const onSearch = (selectedFilters) => {
+		setFilters(selectedFilters)
+		searchExpenses({ variables: buildSearchVariables(selectedFilters, FIRST_PAGE, PAGE_SIZE) })
+	}
+
+	const onChangePage = (selectedPage) => {
+		searchExpenses({ variables: buildSearchVariables(filters, selectedPage, PAGE_SIZE) })
+	}
+
+	if (categoriesQuery.loading) { return <Spinner /> }
+	if (categoriesQuery.error) { return <ErrorAlert errorMessage={categoriesQuery.error.message} /> }
+
+	const hasResults = !searchQuery.loading && !searchQuery.error && Boolean(searchQuery.data)
+
+	return (
+		<Fragment>
+			<SearchExpensesFilters categories={categoriesQuery.data.getExpenseCategory} onSearch={onSearch} />
+
+			{searchQuery.loading && <Spinner />}
+			{searchQuery.error && <ErrorAlert errorMessage={searchQuery.error.message} />}
+			{hasResults && (
+				<SearchExpensesResults
+					searchResult={searchQuery.data.searchExpenses}
+					categories={categoriesQuery.data.getExpenseCategory}
+					onChangePage={onChangePage}
+				/>
+			)}
+		</Fragment>
+	)
+}

--- a/src/components/Expenses/GetSearchExpenses.test.js
+++ b/src/components/Expenses/GetSearchExpenses.test.js
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
+
+import { GetSearchExpenses } from './GetSearchExpenses'
+import { LIST_EXPENSE_CATEGORIES } from '../../gql/queries/expenseCategories'
+
+vi.mock('./SearchExpensesFilters', () => ({
+	SearchExpensesFilters: () => 'filters form'
+}))
+
+vi.mock('./SearchExpensesResults', () => ({
+	SearchExpensesResults: () => 'results'
+}))
+
+const categoriesMock = {
+	request: { query: LIST_EXPENSE_CATEGORIES },
+	result: {
+		data: {
+			getExpenseCategory: [
+				{
+					_id: 'category-id-1',
+					name: 'Private vehicles',
+					emojis: ['🚙'],
+					uuid: 'category-uuid-1',
+					subcategories: [
+						{ _id: 'subcategory-id-1', name: 'Fuel', uuid: 'subcategory-uuid-1', emojis: ['⛽️'] }
+					]
+				}
+			]
+		}
+	}
+}
+
+describe('GetSearchExpenses', () => {
+	it('should display a spinner while the categories are loading', () => {
+		render(
+			<MockedProvider mocks={[categoriesMock]} addTypename={false}>
+				<GetSearchExpenses />
+			</MockedProvider>
+		)
+
+		expect(screen.getByText('Loading...')).toBeInTheDocument()
+	})
+
+	it('should display the filters form once the categories are loaded', async () => {
+		render(
+			<MockedProvider mocks={[categoriesMock]} addTypename={false}>
+				<GetSearchExpenses />
+			</MockedProvider>
+		)
+
+		expect(await screen.findByText('filters form')).toBeInTheDocument()
+	})
+
+	it('should not display any result before the first search', async () => {
+		render(
+			<MockedProvider mocks={[categoriesMock]} addTypename={false}>
+				<GetSearchExpenses />
+			</MockedProvider>
+		)
+
+		await screen.findByText('filters form')
+
+		expect(screen.queryByText('results')).not.toBeInTheDocument()
+	})
+
+	it('should display an alert when the categories cannot be loaded', async () => {
+		const errorMock = {
+			request: { query: LIST_EXPENSE_CATEGORIES },
+			error: new Error('Categories are not available')
+		}
+
+		render(
+			<MockedProvider mocks={[errorMock]} addTypename={false}>
+				<GetSearchExpenses />
+			</MockedProvider>
+		)
+
+		expect(await screen.findByText('Categories are not available')).toBeInTheDocument()
+	})
+})

--- a/src/components/Expenses/GetSearchExpenses.test.js
+++ b/src/components/Expenses/GetSearchExpenses.test.js
@@ -1,16 +1,44 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
 
 import { GetSearchExpenses } from './GetSearchExpenses'
 import { LIST_EXPENSE_CATEGORIES } from '../../gql/queries/expenseCategories'
+import { SEARCH_EXPENSES } from '../../gql/queries/expenses'
+import { buildSearchVariables } from './SearchExpensesFilters/utils'
 
-vi.mock('./SearchExpensesFilters', () => ({
-	SearchExpensesFilters: () => 'filters form'
+const someFilters = vi.hoisted(() => ({
+	category: 'category-id-1',
+	subcategory: 'subcategory-id-1',
+	startDate: null,
+	endDate: null,
+	minQuantity: '',
+	maxQuantity: '',
+	sortBy: 'date',
+	sortDirection: 'desc'
 }))
 
-vi.mock('./SearchExpensesResults', () => ({
-	SearchExpensesResults: () => 'results'
-}))
+vi.mock('./SearchExpensesFilters', () => {
+	const React = require('react')
+	return {
+		SearchExpensesFilters: ({ onSearch }) => React.createElement(
+			'button',
+			{ onClick: () => onSearch(someFilters) },
+			'search'
+		)
+	}
+})
+
+vi.mock('./SearchExpensesResults', () => {
+	const React = require('react')
+	return {
+		SearchExpensesResults: ({ onChangePage }) => React.createElement(
+			'div',
+			null,
+			'results',
+			React.createElement('button', { onClick: () => onChangePage(2) }, 'next page')
+		)
+	}
+})
 
 const categoriesMock = {
 	request: { query: LIST_EXPENSE_CATEGORIES },
@@ -31,6 +59,24 @@ const categoriesMock = {
 	}
 }
 
+const searchResultMock = {
+	expenses: [],
+	pagination: { currentPage: 1, totalPages: 1, totalCount: 0 },
+	totalSum: 0,
+	currencyISO: 'EUR',
+	breakdown: []
+}
+
+const searchExpensesPage1Mock = {
+	request: { query: SEARCH_EXPENSES, variables: buildSearchVariables(someFilters, 1, 25) },
+	result: { data: { searchExpenses: searchResultMock } }
+}
+
+const searchExpensesPage2Mock = {
+	request: { query: SEARCH_EXPENSES, variables: buildSearchVariables(someFilters, 2, 25) },
+	result: { data: { searchExpenses: searchResultMock } }
+}
+
 describe('GetSearchExpenses', () => {
 	it('should display a spinner while the categories are loading', () => {
 		render(
@@ -49,7 +95,7 @@ describe('GetSearchExpenses', () => {
 			</MockedProvider>
 		)
 
-		expect(await screen.findByText('filters form')).toBeInTheDocument()
+		expect(await screen.findByText('search')).toBeInTheDocument()
 	})
 
 	it('should not display any result before the first search', async () => {
@@ -59,7 +105,7 @@ describe('GetSearchExpenses', () => {
 			</MockedProvider>
 		)
 
-		await screen.findByText('filters form')
+		await screen.findByText('search')
 
 		expect(screen.queryByText('results')).not.toBeInTheDocument()
 	})
@@ -77,5 +123,32 @@ describe('GetSearchExpenses', () => {
 		)
 
 		expect(await screen.findByText('Categories are not available')).toBeInTheDocument()
+	})
+
+	it('should run the search with the variables built from the filters and display the results', async () => {
+		render(
+			<MockedProvider mocks={[categoriesMock, searchExpensesPage1Mock]} addTypename={false}>
+				<GetSearchExpenses />
+			</MockedProvider>
+		)
+
+		fireEvent.click(await screen.findByText('search'))
+
+		expect(await screen.findByText('results')).toBeInTheDocument()
+	})
+
+	it('should re-issue the search with the same filters and the new page when the page changes', async () => {
+		render(
+			<MockedProvider mocks={[categoriesMock, searchExpensesPage1Mock, searchExpensesPage2Mock]} addTypename={false}>
+				<GetSearchExpenses />
+			</MockedProvider>
+		)
+
+		fireEvent.click(await screen.findByText('search'))
+		await screen.findByText('results')
+
+		fireEvent.click(screen.getByText('next page'))
+
+		expect(await screen.findByText('results')).toBeInTheDocument()
 	})
 })

--- a/src/components/Expenses/GetSearchExpenses.test.js
+++ b/src/components/Expenses/GetSearchExpenses.test.js
@@ -85,7 +85,7 @@ describe('GetSearchExpenses', () => {
 			</MockedProvider>
 		)
 
-		expect(screen.getByText('Loading...')).toBeInTheDocument()
+		expect(screen.getByText('Loading...')).toBeVisible()
 	})
 
 	it('should display the filters form once the categories are loaded', async () => {
@@ -95,7 +95,7 @@ describe('GetSearchExpenses', () => {
 			</MockedProvider>
 		)
 
-		expect(await screen.findByText('search')).toBeInTheDocument()
+		expect(await screen.findByText('search')).toBeVisible()
 	})
 
 	it('should not display any result before the first search', async () => {
@@ -122,7 +122,7 @@ describe('GetSearchExpenses', () => {
 			</MockedProvider>
 		)
 
-		expect(await screen.findByText('Categories are not available')).toBeInTheDocument()
+		expect(await screen.findByText('Categories are not available')).toBeVisible()
 	})
 
 	it('should run the search with the variables built from the filters and display the results', async () => {
@@ -134,7 +134,7 @@ describe('GetSearchExpenses', () => {
 
 		fireEvent.click(await screen.findByText('search'))
 
-		expect(await screen.findByText('results')).toBeInTheDocument()
+		expect(await screen.findByText('results')).toBeVisible()
 	})
 
 	it('should re-issue the search with the same filters and the new page when the page changes', async () => {
@@ -149,6 +149,6 @@ describe('GetSearchExpenses', () => {
 
 		fireEvent.click(screen.getByText('next page'))
 
-		expect(await screen.findByText('results')).toBeInTheDocument()
+		expect(await screen.findByText('results')).toBeVisible()
 	})
 })

--- a/src/components/Expenses/SearchExpensesFilters/index.js
+++ b/src/components/Expenses/SearchExpensesFilters/index.js
@@ -1,0 +1,155 @@
+import { useState } from 'react'
+import PropTypes from 'prop-types'
+
+import Moment from 'moment'
+import momentLocalizer from 'react-widgets-moment'
+import { DatePicker } from 'react-widgets'
+import { Collapse } from 'reactstrap'
+import 'react-widgets/dist/css/react-widgets.css'
+
+Moment.locale('en', {
+	week: {
+		dow: 1 // Monday is the first day of the week.
+	}
+})
+momentLocalizer()
+
+const INITIAL_FILTERS = {
+	category: '',
+	subcategory: '',
+	startDate: null,
+	endDate: null,
+	minQuantity: '',
+	maxQuantity: '',
+	sortBy: 'date',
+	sortDirection: 'desc'
+}
+
+const SELECT_CLASS_NAME = 'form-select bg-dark text-light border-secondary'
+const INPUT_CLASS_NAME = 'form-control bg-dark text-light border-secondary'
+
+export const SearchExpensesFilters = ({ categories, onSearch }) => {
+	const [filters, setFilters] = useState(INITIAL_FILTERS)
+	const [isOpen, setIsOpen] = useState(true)
+
+	const selectedCategory = categories.find(category => category._id === filters.category)
+	const subcategories = selectedCategory ? selectedCategory.subcategories : []
+
+	const onChangeCategory = (event) => {
+		setFilters({ ...filters, category: event.target.value, subcategory: '' })
+	}
+
+	const onChangeField = (field) => (event) => {
+		setFilters({ ...filters, [field]: event.target.value })
+	}
+
+	const onChangeDate = (field) => (date) => {
+		setFilters({ ...filters, [field]: date })
+	}
+
+	const onSubmit = (event) => {
+		event.preventDefault()
+		setIsOpen(false)
+		onSearch(filters)
+	}
+
+	return (
+		<section className="mb-4">
+			<button
+				type="button"
+				className="btn btn-outline-info w-100 mb-2"
+				onClick={() => setIsOpen(!isOpen)}
+				aria-expanded={isOpen}
+			>
+				Filters
+			</button>
+
+			<Collapse isOpen={isOpen}>
+				<form onSubmit={onSubmit} className="card bg-dark border-secondary p-3">
+					<div className="mb-3">
+						<label className="form-label text-muted" htmlFor="category">Category</label>
+						<select id="category" className={SELECT_CLASS_NAME} value={filters.category} onChange={onChangeCategory}>
+							<option value="">All categories</option>
+							{
+								categories.map(category => (
+									<option key={category._id} value={category._id}>{category.name}</option>
+								))
+							}
+						</select>
+					</div>
+
+					<div className="mb-3">
+						<label className="form-label text-muted" htmlFor="subcategory">Subcategory</label>
+						<select id="subcategory" className={SELECT_CLASS_NAME} value={filters.subcategory} onChange={onChangeField('subcategory')} disabled={!subcategories.length}>
+							<option value="">All subcategories</option>
+							{
+								subcategories.map(subcategory => (
+									<option key={subcategory._id} value={subcategory._id}>{subcategory.name}</option>
+								))
+							}
+						</select>
+					</div>
+
+					<div className="row">
+						<div className="col-6 mb-3">
+							<label className="form-label text-muted" htmlFor="startDate">From</label>
+							<DatePicker id="startDate" value={filters.startDate} onChange={onChangeDate('startDate')} />
+						</div>
+						<div className="col-6 mb-3">
+							<label className="form-label text-muted" htmlFor="endDate">To</label>
+							<DatePicker id="endDate" value={filters.endDate} onChange={onChangeDate('endDate')} />
+						</div>
+					</div>
+
+					<div className="row">
+						<div className="col-6 mb-3">
+							<label className="form-label text-muted" htmlFor="minQuantity">Min amount</label>
+							<input id="minQuantity" type="text" inputMode="decimal" className={INPUT_CLASS_NAME} value={filters.minQuantity} onChange={onChangeField('minQuantity')} />
+						</div>
+						<div className="col-6 mb-3">
+							<label className="form-label text-muted" htmlFor="maxQuantity">Max amount</label>
+							<input id="maxQuantity" type="text" inputMode="decimal" className={INPUT_CLASS_NAME} value={filters.maxQuantity} onChange={onChangeField('maxQuantity')} />
+						</div>
+					</div>
+
+					<div className="row">
+						<div className="col-6 mb-3">
+							<label className="form-label text-muted" htmlFor="sortBy">Sort by</label>
+							<select id="sortBy" className={SELECT_CLASS_NAME} value={filters.sortBy} onChange={onChangeField('sortBy')}>
+								<option value="date">Date</option>
+								<option value="quantity">Amount</option>
+							</select>
+						</div>
+						<div className="col-6 mb-3">
+							<label className="form-label text-muted" htmlFor="sortDirection">Order</label>
+							<select id="sortDirection" className={SELECT_CLASS_NAME} value={filters.sortDirection} onChange={onChangeField('sortDirection')}>
+								<option value="desc">Descending</option>
+								<option value="asc">Ascending</option>
+							</select>
+						</div>
+					</div>
+
+					<button type="submit" className="btn btn-info">Search</button>
+				</form>
+			</Collapse>
+		</section>
+	)
+}
+
+SearchExpensesFilters.propTypes = {
+	categories: PropTypes.arrayOf(
+		PropTypes.shape({
+			_id: PropTypes.string.isRequired,
+			name: PropTypes.string.isRequired,
+			subcategories: PropTypes.arrayOf(
+				PropTypes.shape({
+					_id: PropTypes.string.isRequired,
+					name: PropTypes.string.isRequired,
+					uuid: PropTypes.string.isRequired
+				})
+			),
+			uuid: PropTypes.string.isRequired
+		})
+	).isRequired,
+	onSearch: PropTypes.func.isRequired
+}

--- a/src/components/Expenses/SearchExpensesFilters/index.js
+++ b/src/components/Expenses/SearchExpensesFilters/index.js
@@ -1,21 +1,13 @@
 import { useState } from 'react'
 import PropTypes from 'prop-types'
 
-import Moment from 'moment'
-import momentLocalizer from 'react-widgets-moment'
 import { DatePicker } from 'react-widgets'
 import { Collapse } from 'reactstrap'
 import 'react-widgets/dist/css/react-widgets.css'
 import './styles.css'
 
+import '../../../utils/dateLocalizer'
 import { buildFiltersSummary, isValidAmountInput } from './utils'
-
-Moment.locale('en', {
-	week: {
-		dow: 1 // Monday is the first day of the week.
-	}
-})
-momentLocalizer()
 
 const INITIAL_FILTERS = {
 	category: '',

--- a/src/components/Expenses/SearchExpensesFilters/index.js
+++ b/src/components/Expenses/SearchExpensesFilters/index.js
@@ -71,6 +71,16 @@ export const SearchExpensesFilters = ({ categories, onSearch }) => {
 		inputProps: { 'aria-label': label, readOnly: true, onClick: () => setOpenPicker(field) }
 	})
 
+	// The selector is disabled in two different situations, and Bootstrap's disabled styling is too
+	// subtle to notice on a phone. Saying why it cannot be used beats making it look greyer
+	const getSubcategoryPlaceholder = () => {
+		if (filters.category === '') {
+			return 'Select a category first'
+		}
+
+		return subcategories.length ? 'All subcategories' : 'No subcategories'
+	}
+
 	const onSubmit = (event) => {
 		event.preventDefault()
 		setIsOpen(false)
@@ -110,7 +120,7 @@ export const SearchExpensesFilters = ({ categories, onSearch }) => {
 					<div className="mb-3">
 						<label className="form-label text-muted" htmlFor="subcategory">Subcategory</label>
 						<select id="subcategory" className={SELECT_CLASS_NAME} value={filters.subcategory} onChange={onChangeField('subcategory')} disabled={!subcategories.length}>
-							<option value="">All subcategories</option>
+							<option value="">{getSubcategoryPlaceholder()}</option>
 							{
 								subcategories.map(subcategory => (
 									<option key={subcategory._id} value={subcategory._id}>{subcategory.name}</option>

--- a/src/components/Expenses/SearchExpensesFilters/index.js
+++ b/src/components/Expenses/SearchExpensesFilters/index.js
@@ -6,6 +6,7 @@ import momentLocalizer from 'react-widgets-moment'
 import { DatePicker } from 'react-widgets'
 import { Collapse } from 'reactstrap'
 import 'react-widgets/dist/css/react-widgets.css'
+import './styles.css'
 
 import { buildFiltersSummary, isValidAmountInput } from './utils'
 
@@ -27,13 +28,16 @@ const INITIAL_FILTERS = {
 	sortDirection: 'desc'
 }
 
-const SELECT_CLASS_NAME = 'form-select bg-dark text-light border-secondary'
-const INPUT_CLASS_NAME = 'form-control bg-dark text-light border-secondary'
+const SELECT_CLASS_NAME = 'form-select'
+const INPUT_CLASS_NAME = 'form-control'
 const FILTERS_PANEL_ID = 'searchExpensesFiltersPanel'
+// Matches how the results table renders dates, and avoids the ambiguity of a day/month order
+const DATE_FORMAT = 'YYYY-MM-DD'
 
 export const SearchExpensesFilters = ({ categories, onSearch }) => {
 	const [filters, setFilters] = useState(INITIAL_FILTERS)
 	const [isOpen, setIsOpen] = useState(true)
+	const [openPicker, setOpenPicker] = useState(null)
 
 	const selectedCategory = categories.find(category => category._id === filters.category)
 	const subcategories = selectedCategory ? selectedCategory.subcategories : []
@@ -49,6 +53,23 @@ export const SearchExpensesFilters = ({ categories, onSearch }) => {
 	const onChangeDate = (field) => (date) => {
 		setFilters({ ...filters, [field]: date })
 	}
+
+	// The date inputs are read only so a typed date can never be silently discarded:
+	// the calendar is the only way in, and tapping the field opens it
+	const onTogglePicker = (field) => (isPickerOpen) => {
+		setOpenPicker(isPickerOpen ? field : null)
+	}
+
+	const getDatePickerProps = (field, label) => ({
+		id: field,
+		format: DATE_FORMAT,
+		value: filters[field],
+		onChange: onChangeDate(field),
+		// react-widgets types this prop as false | 'date' | 'time'; a boolean silently never opens
+		open: openPicker === field ? 'date' : false,
+		onToggle: onTogglePicker(field),
+		inputProps: { 'aria-label': label, readOnly: true, onClick: () => setOpenPicker(field) }
+	})
 
 	const onSubmit = (event) => {
 		event.preventDefault()
@@ -73,7 +94,7 @@ export const SearchExpensesFilters = ({ categories, onSearch }) => {
 			</button>
 
 			<Collapse id={FILTERS_PANEL_ID} isOpen={isOpen}>
-				<form onSubmit={onSubmit} className="card bg-dark border-secondary p-3">
+				<form onSubmit={onSubmit} className="card bg-dark border-secondary p-3 search-expenses-filters">
 					<div className="mb-3">
 						<label className="form-label text-muted" htmlFor="category">Category</label>
 						<select id="category" className={SELECT_CLASS_NAME} value={filters.category} onChange={onChangeCategory}>
@@ -101,11 +122,11 @@ export const SearchExpensesFilters = ({ categories, onSearch }) => {
 					<div className="row">
 						<div className="col-12 col-sm-6 mb-3">
 							<label className="form-label text-muted" htmlFor="startDate">From</label>
-							<DatePicker id="startDate" inputProps={{ 'aria-label': 'From' }} value={filters.startDate} onChange={onChangeDate('startDate')} />
+							<DatePicker {...getDatePickerProps('startDate', 'From')} />
 						</div>
 						<div className="col-12 col-sm-6 mb-3">
 							<label className="form-label text-muted" htmlFor="endDate">To</label>
-							<DatePicker id="endDate" inputProps={{ 'aria-label': 'To' }} value={filters.endDate} onChange={onChangeDate('endDate')} />
+							<DatePicker {...getDatePickerProps('endDate', 'To')} />
 						</div>
 					</div>
 

--- a/src/components/Expenses/SearchExpensesFilters/index.js
+++ b/src/components/Expenses/SearchExpensesFilters/index.js
@@ -23,7 +23,6 @@ const INITIAL_FILTERS = {
 const SELECT_CLASS_NAME = 'form-select'
 const INPUT_CLASS_NAME = 'form-control'
 const FILTERS_PANEL_ID = 'searchExpensesFiltersPanel'
-// Matches how the results table renders dates, and avoids the ambiguity of a day/month order
 const DATE_FORMAT = 'YYYY-MM-DD'
 
 export const SearchExpensesFilters = ({ categories, onSearch }) => {
@@ -46,8 +45,6 @@ export const SearchExpensesFilters = ({ categories, onSearch }) => {
 		setFilters({ ...filters, [field]: date })
 	}
 
-	// The date inputs are read only so a typed date can never be silently discarded:
-	// the calendar is the only way in, and tapping the field opens it
 	const onTogglePicker = (field) => (isPickerOpen) => {
 		setOpenPicker(isPickerOpen ? field : null)
 	}
@@ -63,8 +60,6 @@ export const SearchExpensesFilters = ({ categories, onSearch }) => {
 		inputProps: { 'aria-label': label, readOnly: true, onClick: () => setOpenPicker(field) }
 	})
 
-	// The selector is disabled in two different situations, and Bootstrap's disabled styling is too
-	// subtle to notice on a phone. Saying why it cannot be used beats making it look greyer
 	const getSubcategoryPlaceholder = () => {
 		if (filters.category === '') {
 			return 'Select a category first'

--- a/src/components/Expenses/SearchExpensesFilters/index.js
+++ b/src/components/Expenses/SearchExpensesFilters/index.js
@@ -7,6 +7,8 @@ import { DatePicker } from 'react-widgets'
 import { Collapse } from 'reactstrap'
 import 'react-widgets/dist/css/react-widgets.css'
 
+import { buildFiltersSummary, isValidAmountInput } from './utils'
+
 Moment.locale('en', {
 	week: {
 		dow: 1 // Monday is the first day of the week.
@@ -27,6 +29,7 @@ const INITIAL_FILTERS = {
 
 const SELECT_CLASS_NAME = 'form-select bg-dark text-light border-secondary'
 const INPUT_CLASS_NAME = 'form-control bg-dark text-light border-secondary'
+const FILTERS_PANEL_ID = 'searchExpensesFiltersPanel'
 
 export const SearchExpensesFilters = ({ categories, onSearch }) => {
 	const [filters, setFilters] = useState(INITIAL_FILTERS)
@@ -53,6 +56,10 @@ export const SearchExpensesFilters = ({ categories, onSearch }) => {
 		onSearch(filters)
 	}
 
+	const isMinQuantityValid = isValidAmountInput(filters.minQuantity)
+	const isMaxQuantityValid = isValidAmountInput(filters.maxQuantity)
+	const isAmountInvalid = !isMinQuantityValid || !isMaxQuantityValid
+
 	return (
 		<section className="mb-4">
 			<button
@@ -60,11 +67,12 @@ export const SearchExpensesFilters = ({ categories, onSearch }) => {
 				className="btn btn-outline-info w-100 mb-2"
 				onClick={() => setIsOpen(!isOpen)}
 				aria-expanded={isOpen}
+				aria-controls={FILTERS_PANEL_ID}
 			>
-				Filters
+				{buildFiltersSummary(filters, categories)}
 			</button>
 
-			<Collapse isOpen={isOpen}>
+			<Collapse id={FILTERS_PANEL_ID} isOpen={isOpen}>
 				<form onSubmit={onSubmit} className="card bg-dark border-secondary p-3">
 					<div className="mb-3">
 						<label className="form-label text-muted" htmlFor="category">Category</label>
@@ -91,13 +99,13 @@ export const SearchExpensesFilters = ({ categories, onSearch }) => {
 					</div>
 
 					<div className="row">
-						<div className="col-6 mb-3">
+						<div className="col-12 col-sm-6 mb-3">
 							<label className="form-label text-muted" htmlFor="startDate">From</label>
-							<DatePicker id="startDate" value={filters.startDate} onChange={onChangeDate('startDate')} />
+							<DatePicker id="startDate" inputProps={{ 'aria-label': 'From' }} value={filters.startDate} onChange={onChangeDate('startDate')} />
 						</div>
-						<div className="col-6 mb-3">
+						<div className="col-12 col-sm-6 mb-3">
 							<label className="form-label text-muted" htmlFor="endDate">To</label>
-							<DatePicker id="endDate" value={filters.endDate} onChange={onChangeDate('endDate')} />
+							<DatePicker id="endDate" inputProps={{ 'aria-label': 'To' }} value={filters.endDate} onChange={onChangeDate('endDate')} />
 						</div>
 					</div>
 
@@ -110,6 +118,13 @@ export const SearchExpensesFilters = ({ categories, onSearch }) => {
 							<label className="form-label text-muted" htmlFor="maxQuantity">Max amount</label>
 							<input id="maxQuantity" type="text" inputMode="decimal" className={INPUT_CLASS_NAME} value={filters.maxQuantity} onChange={onChangeField('maxQuantity')} />
 						</div>
+						{
+							isAmountInvalid && (
+								<div className="col-12">
+									<small className="d-block text-muted mb-3">Amount must be a number using a decimal point or comma</small>
+								</div>
+							)
+						}
 					</div>
 
 					<div className="row">
@@ -129,7 +144,7 @@ export const SearchExpensesFilters = ({ categories, onSearch }) => {
 						</div>
 					</div>
 
-					<button type="submit" className="btn btn-info">Search</button>
+					<button type="submit" className="btn btn-info" disabled={isAmountInvalid}>Search</button>
 				</form>
 			</Collapse>
 		</section>

--- a/src/components/Expenses/SearchExpensesFilters/index.test.js
+++ b/src/components/Expenses/SearchExpensesFilters/index.test.js
@@ -41,13 +41,19 @@ describe('SearchExpensesFilters', () => {
 	})
 
 	it('should reset the selected subcategory when the category changes', () => {
-		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
+		const onSearch = vi.fn()
+
+		render(<SearchExpensesFilters categories={categories} onSearch={onSearch} />)
 
 		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-1' } })
 		fireEvent.change(screen.getByLabelText('Subcategory'), { target: { value: 'subcategory-id-1' } })
 		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-2' } })
 
 		expect(screen.getByLabelText('Subcategory')).toHaveValue('')
+
+		fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+
+		expect(onSearch).toHaveBeenCalledWith(expect.objectContaining({ subcategory: '' }))
 	})
 
 	it('should call onSearch with the filters filled in', () => {
@@ -86,7 +92,7 @@ describe('SearchExpensesFilters', () => {
 	it('should collapse the filters after searching, and expand them again on demand', () => {
 		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
 
-		const toggle = screen.getByRole('button', { name: 'Filters' })
+		const toggle = screen.getByRole('button', { name: 'All categories' })
 		expect(toggle).toHaveAttribute('aria-expanded', 'true')
 
 		fireEvent.click(screen.getByRole('button', { name: 'Search' }))
@@ -94,5 +100,74 @@ describe('SearchExpensesFilters', () => {
 
 		fireEvent.click(toggle)
 		expect(toggle).toHaveAttribute('aria-expanded', 'true')
+	})
+
+	it('should point the toggle button at the collapsed region via aria-controls', () => {
+		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
+
+		const toggle = screen.getByRole('button', { name: 'All categories' })
+		const panelId = toggle.getAttribute('aria-controls')
+
+		expect(panelId).toBeTruthy()
+		expect(document.getElementById(panelId)).toBeInTheDocument()
+	})
+
+	it('should summarize the active filters as the toggle button label', () => {
+		const onSearch = vi.fn()
+
+		render(<SearchExpensesFilters categories={categories} onSearch={onSearch} />)
+
+		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-1' } })
+
+		expect(screen.getByRole('button', { name: 'Private vehicles' })).toBeInTheDocument()
+
+		fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+
+		expect(screen.getByRole('button', { name: 'Private vehicles' })).toHaveAttribute('aria-expanded', 'false')
+	})
+
+	it('should give the date fields an accessible name reaching the real input', () => {
+		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
+
+		expect(screen.getByLabelText('From')).toBeInTheDocument()
+		expect(screen.getByLabelText('To')).toBeInTheDocument()
+	})
+
+	it('should reach onSearch with a Date when a start date is typed into the field', () => {
+		const onSearch = vi.fn()
+
+		render(<SearchExpensesFilters categories={categories} onSearch={onSearch} />)
+
+		fireEvent.change(screen.getByLabelText('From'), { target: { value: '02/01/2026' } })
+		fireEvent.blur(screen.getByLabelText('From'))
+		fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+
+		expect(onSearch).toHaveBeenCalledTimes(1)
+		expect(onSearch.mock.calls[0][0].startDate).toBeInstanceOf(Date)
+	})
+
+	it('should disable the Search button and show a message when an amount is not a valid number', () => {
+		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
+
+		fireEvent.change(screen.getByLabelText('Min amount'), { target: { value: 'abc' } })
+
+		expect(screen.getByRole('button', { name: 'Search' })).toBeDisabled()
+		expect(screen.getByText('Amount must be a number using a decimal point or comma')).toBeInTheDocument()
+	})
+
+	it('should keep the Search button enabled when the amount is a valid number', () => {
+		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
+
+		fireEvent.change(screen.getByLabelText('Min amount'), { target: { value: '23,15' } })
+
+		expect(screen.getByRole('button', { name: 'Search' })).not.toBeDisabled()
+		expect(screen.queryByText('Amount must be a number using a decimal point or comma')).not.toBeInTheDocument()
+	})
+
+	it('should keep the Search button enabled when the amount is left empty', () => {
+		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
+
+		expect(screen.getByRole('button', { name: 'Search' })).not.toBeDisabled()
+		expect(screen.queryByText('Amount must be a number using a decimal point or comma')).not.toBeInTheDocument()
 	})
 })

--- a/src/components/Expenses/SearchExpensesFilters/index.test.js
+++ b/src/components/Expenses/SearchExpensesFilters/index.test.js
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { SearchExpensesFilters } from './'
+
+const categories = [
+	{
+		_id: 'category-id-1',
+		name: 'Private vehicles',
+		uuid: 'category-uuid-1',
+		subcategories: [
+			{ _id: 'subcategory-id-1', name: 'Fuel', uuid: 'subcategory-uuid-1' },
+			{ _id: 'subcategory-id-2', name: 'Garage', uuid: 'subcategory-uuid-2' }
+		]
+	},
+	{
+		_id: 'category-id-2',
+		name: 'Home',
+		uuid: 'category-uuid-2',
+		subcategories: [
+			{ _id: 'subcategory-id-3', name: 'Electricity bill', uuid: 'subcategory-uuid-3' }
+		]
+	}
+]
+
+describe('SearchExpensesFilters', () => {
+	it('should disable the subcategory selector while no category is selected', () => {
+		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
+
+		expect(screen.getByLabelText('Subcategory')).toBeDisabled()
+	})
+
+	it('should offer the subcategories of the selected category', () => {
+		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
+
+		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-1' } })
+
+		expect(screen.getByLabelText('Subcategory')).not.toBeDisabled()
+		expect(screen.getByRole('option', { name: 'Fuel' })).toBeInTheDocument()
+		expect(screen.getByRole('option', { name: 'Garage' })).toBeInTheDocument()
+		expect(screen.queryByRole('option', { name: 'Electricity bill' })).not.toBeInTheDocument()
+	})
+
+	it('should reset the selected subcategory when the category changes', () => {
+		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
+
+		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-1' } })
+		fireEvent.change(screen.getByLabelText('Subcategory'), { target: { value: 'subcategory-id-1' } })
+		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-2' } })
+
+		expect(screen.getByLabelText('Subcategory')).toHaveValue('')
+	})
+
+	it('should call onSearch with the filters filled in', () => {
+		const onSearch = vi.fn()
+
+		render(<SearchExpensesFilters categories={categories} onSearch={onSearch} />)
+
+		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-1' } })
+		fireEvent.change(screen.getByLabelText('Min amount'), { target: { value: '23,15' } })
+		fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+
+		expect(onSearch).toHaveBeenCalledTimes(1)
+		expect(onSearch).toHaveBeenCalledWith({
+			category: 'category-id-1',
+			subcategory: '',
+			startDate: null,
+			endDate: null,
+			minQuantity: '23,15',
+			maxQuantity: '',
+			sortBy: 'date',
+			sortDirection: 'desc'
+		})
+	})
+
+	it('should search sorted by date descending by default', () => {
+		const onSearch = vi.fn()
+
+		render(<SearchExpensesFilters categories={categories} onSearch={onSearch} />)
+
+		fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+
+		expect(onSearch.mock.calls[0][0].sortBy).toBe('date')
+		expect(onSearch.mock.calls[0][0].sortDirection).toBe('desc')
+	})
+
+	it('should collapse the filters after searching, and expand them again on demand', () => {
+		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
+
+		const toggle = screen.getByRole('button', { name: 'Filters' })
+		expect(toggle).toHaveAttribute('aria-expanded', 'true')
+
+		fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+		expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+		fireEvent.click(toggle)
+		expect(toggle).toHaveAttribute('aria-expanded', 'true')
+	})
+})

--- a/src/components/Expenses/SearchExpensesFilters/index.test.js
+++ b/src/components/Expenses/SearchExpensesFilters/index.test.js
@@ -29,6 +29,19 @@ describe('SearchExpensesFilters', () => {
 		expect(screen.getByLabelText('Subcategory')).toBeDisabled()
 	})
 
+	it('should keep the subcategory selector disabled for a category that has no subcategories', () => {
+		const categoriesWithoutSubcategories = [
+			{ _id: 'category-id-3', name: 'Public transport', uuid: 'category-uuid-3', subcategories: [] }
+		]
+
+		render(<SearchExpensesFilters categories={categoriesWithoutSubcategories} onSearch={vi.fn()} />)
+
+		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-3' } })
+
+		expect(screen.getByLabelText('Category')).toHaveValue('category-id-3')
+		expect(screen.getByLabelText('Subcategory')).toBeDisabled()
+	})
+
 	it('should offer the subcategories of the selected category', () => {
 		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
 

--- a/src/components/Expenses/SearchExpensesFilters/index.test.js
+++ b/src/components/Expenses/SearchExpensesFilters/index.test.js
@@ -133,13 +133,33 @@ describe('SearchExpensesFilters', () => {
 		expect(screen.getByLabelText('To')).toBeInTheDocument()
 	})
 
-	it('should reach onSearch with a Date when a start date is typed into the field', () => {
+	it('should keep the date fields read only, so a typed date can never be silently discarded', () => {
+		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
+
+		expect(screen.getByLabelText('From')).toHaveAttribute('readonly')
+		expect(screen.getByLabelText('To')).toHaveAttribute('readonly')
+	})
+
+	it('should open the calendar when a date field is tapped', () => {
+		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
+
+		expect(document.querySelector('table')).not.toBeInTheDocument()
+
+		fireEvent.click(screen.getByLabelText('From'))
+
+		expect(document.querySelector('table')).toBeInTheDocument()
+	})
+
+	it('should reach onSearch with a Date when a day is picked from the calendar', () => {
 		const onSearch = vi.fn()
 
 		render(<SearchExpensesFilters categories={categories} onSearch={onSearch} />)
 
-		fireEvent.change(screen.getByLabelText('From'), { target: { value: '02/01/2026' } })
-		fireEvent.blur(screen.getByLabelText('From'))
+		fireEvent.click(screen.getByLabelText('From'))
+
+		const dayCells = document.querySelectorAll('table tbody td')
+		fireEvent.click(dayCells[15])
+
 		fireEvent.click(screen.getByRole('button', { name: 'Search' }))
 
 		expect(onSearch).toHaveBeenCalledTimes(1)

--- a/src/components/Expenses/SearchExpensesFilters/index.test.js
+++ b/src/components/Expenses/SearchExpensesFilters/index.test.js
@@ -29,6 +29,25 @@ describe('SearchExpensesFilters', () => {
 		expect(screen.getByLabelText('Subcategory')).toBeDisabled()
 	})
 
+	it('should say why the subcategory selector cannot be used, in each of the two cases', () => {
+		const mixedCategories = [
+			...categories,
+			{ _id: 'category-id-3', name: 'Public transport', uuid: 'category-uuid-3', subcategories: [] }
+		]
+
+		render(<SearchExpensesFilters categories={mixedCategories} onSearch={vi.fn()} />)
+
+		expect(screen.getByRole('option', { name: 'Select a category first' })).toBeInTheDocument()
+
+		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-3' } })
+
+		expect(screen.getByRole('option', { name: 'No subcategories' })).toBeInTheDocument()
+
+		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-1' } })
+
+		expect(screen.getByRole('option', { name: 'All subcategories' })).toBeInTheDocument()
+	})
+
 	it('should keep the subcategory selector disabled for a category that has no subcategories', () => {
 		const categoriesWithoutSubcategories = [
 			{ _id: 'category-id-3', name: 'Public transport', uuid: 'category-uuid-3', subcategories: [] }
@@ -185,7 +204,7 @@ describe('SearchExpensesFilters', () => {
 		fireEvent.change(screen.getByLabelText('Min amount'), { target: { value: 'abc' } })
 
 		expect(screen.getByRole('button', { name: 'Search' })).toBeDisabled()
-		expect(screen.getByText('Amount must be a number using a decimal point or comma')).toBeInTheDocument()
+		expect(screen.getByText('Amount must be a number using a decimal point or comma')).toBeVisible()
 	})
 
 	it('should keep the Search button enabled when the amount is a valid number', () => {

--- a/src/components/Expenses/SearchExpensesFilters/index.test.js
+++ b/src/components/Expenses/SearchExpensesFilters/index.test.js
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { SearchExpensesFilters } from './'
 
@@ -22,6 +23,8 @@ const categories = [
 	}
 ]
 
+const categoryWithoutSubcategories = { _id: 'category-id-3', name: 'Public transport', uuid: 'category-uuid-3', subcategories: [] }
+
 describe('SearchExpensesFilters', () => {
 	it('should disable the subcategory selector while no category is selected', () => {
 		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
@@ -29,42 +32,39 @@ describe('SearchExpensesFilters', () => {
 		expect(screen.getByLabelText('Subcategory')).toBeDisabled()
 	})
 
-	it('should say why the subcategory selector cannot be used, in each of the two cases', () => {
-		const mixedCategories = [
-			...categories,
-			{ _id: 'category-id-3', name: 'Public transport', uuid: 'category-uuid-3', subcategories: [] }
-		]
+	it('should say why the subcategory selector cannot be used, in each of the two cases', async () => {
+		const user = userEvent.setup()
 
-		render(<SearchExpensesFilters categories={mixedCategories} onSearch={vi.fn()} />)
+		render(<SearchExpensesFilters categories={[...categories, categoryWithoutSubcategories]} onSearch={vi.fn()} />)
 
 		expect(screen.getByRole('option', { name: 'Select a category first' })).toBeInTheDocument()
 
-		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-3' } })
+		await user.selectOptions(screen.getByLabelText('Category'), 'category-id-3')
 
 		expect(screen.getByRole('option', { name: 'No subcategories' })).toBeInTheDocument()
 
-		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-1' } })
+		await user.selectOptions(screen.getByLabelText('Category'), 'category-id-1')
 
 		expect(screen.getByRole('option', { name: 'All subcategories' })).toBeInTheDocument()
 	})
 
-	it('should keep the subcategory selector disabled for a category that has no subcategories', () => {
-		const categoriesWithoutSubcategories = [
-			{ _id: 'category-id-3', name: 'Public transport', uuid: 'category-uuid-3', subcategories: [] }
-		]
+	it('should keep the subcategory selector disabled for a category that has no subcategories', async () => {
+		const user = userEvent.setup()
 
-		render(<SearchExpensesFilters categories={categoriesWithoutSubcategories} onSearch={vi.fn()} />)
+		render(<SearchExpensesFilters categories={[categoryWithoutSubcategories]} onSearch={vi.fn()} />)
 
-		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-3' } })
+		await user.selectOptions(screen.getByLabelText('Category'), 'category-id-3')
 
 		expect(screen.getByLabelText('Category')).toHaveValue('category-id-3')
 		expect(screen.getByLabelText('Subcategory')).toBeDisabled()
 	})
 
-	it('should offer the subcategories of the selected category', () => {
+	it('should offer the subcategories of the selected category', async () => {
+		const user = userEvent.setup()
+
 		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
 
-		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-1' } })
+		await user.selectOptions(screen.getByLabelText('Category'), 'category-id-1')
 
 		expect(screen.getByLabelText('Subcategory')).not.toBeDisabled()
 		expect(screen.getByRole('option', { name: 'Fuel' })).toBeInTheDocument()
@@ -72,30 +72,32 @@ describe('SearchExpensesFilters', () => {
 		expect(screen.queryByRole('option', { name: 'Electricity bill' })).not.toBeInTheDocument()
 	})
 
-	it('should reset the selected subcategory when the category changes', () => {
+	it('should reset the selected subcategory when the category changes', async () => {
+		const user = userEvent.setup()
 		const onSearch = vi.fn()
 
 		render(<SearchExpensesFilters categories={categories} onSearch={onSearch} />)
 
-		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-1' } })
-		fireEvent.change(screen.getByLabelText('Subcategory'), { target: { value: 'subcategory-id-1' } })
-		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-2' } })
+		await user.selectOptions(screen.getByLabelText('Category'), 'category-id-1')
+		await user.selectOptions(screen.getByLabelText('Subcategory'), 'subcategory-id-1')
+		await user.selectOptions(screen.getByLabelText('Category'), 'category-id-2')
 
 		expect(screen.getByLabelText('Subcategory')).toHaveValue('')
 
-		fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+		await user.click(screen.getByRole('button', { name: 'Search' }))
 
 		expect(onSearch).toHaveBeenCalledWith(expect.objectContaining({ subcategory: '' }))
 	})
 
-	it('should call onSearch with the filters filled in', () => {
+	it('should call onSearch with the filters filled in', async () => {
+		const user = userEvent.setup()
 		const onSearch = vi.fn()
 
 		render(<SearchExpensesFilters categories={categories} onSearch={onSearch} />)
 
-		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-1' } })
-		fireEvent.change(screen.getByLabelText('Min amount'), { target: { value: '23,15' } })
-		fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+		await user.selectOptions(screen.getByLabelText('Category'), 'category-id-1')
+		await user.type(screen.getByLabelText('Min amount'), '23,15')
+		await user.click(screen.getByRole('button', { name: 'Search' }))
 
 		expect(onSearch).toHaveBeenCalledTimes(1)
 		expect(onSearch).toHaveBeenCalledWith({
@@ -110,27 +112,30 @@ describe('SearchExpensesFilters', () => {
 		})
 	})
 
-	it('should search sorted by date descending by default', () => {
+	it('should search sorted by date descending by default', async () => {
+		const user = userEvent.setup()
 		const onSearch = vi.fn()
 
 		render(<SearchExpensesFilters categories={categories} onSearch={onSearch} />)
 
-		fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+		await user.click(screen.getByRole('button', { name: 'Search' }))
 
 		expect(onSearch.mock.calls[0][0].sortBy).toBe('date')
 		expect(onSearch.mock.calls[0][0].sortDirection).toBe('desc')
 	})
 
-	it('should collapse the filters after searching, and expand them again on demand', () => {
+	it('should collapse the filters after searching, and expand them again on demand', async () => {
+		const user = userEvent.setup()
+
 		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
 
 		const toggle = screen.getByRole('button', { name: 'All categories' })
 		expect(toggle).toHaveAttribute('aria-expanded', 'true')
 
-		fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+		await user.click(screen.getByRole('button', { name: 'Search' }))
 		expect(toggle).toHaveAttribute('aria-expanded', 'false')
 
-		fireEvent.click(toggle)
+		await user.click(toggle)
 		expect(toggle).toHaveAttribute('aria-expanded', 'true')
 	})
 
@@ -141,19 +146,19 @@ describe('SearchExpensesFilters', () => {
 		const panelId = toggle.getAttribute('aria-controls')
 
 		expect(panelId).toBeTruthy()
-		expect(document.getElementById(panelId)).toBeInTheDocument()
+		expect(document.getElementById(panelId)).toBeVisible()
 	})
 
-	it('should summarize the active filters as the toggle button label', () => {
-		const onSearch = vi.fn()
+	it('should summarize the active filters as the toggle button label', async () => {
+		const user = userEvent.setup()
 
-		render(<SearchExpensesFilters categories={categories} onSearch={onSearch} />)
+		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
 
-		fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'category-id-1' } })
+		await user.selectOptions(screen.getByLabelText('Category'), 'category-id-1')
 
-		expect(screen.getByRole('button', { name: 'Private vehicles' })).toBeInTheDocument()
+		expect(screen.getByRole('button', { name: 'Private vehicles' })).toBeVisible()
 
-		fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+		await user.click(screen.getByRole('button', { name: 'Search' }))
 
 		expect(screen.getByRole('button', { name: 'Private vehicles' })).toHaveAttribute('aria-expanded', 'false')
 	})
@@ -161,8 +166,8 @@ describe('SearchExpensesFilters', () => {
 	it('should give the date fields an accessible name reaching the real input', () => {
 		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
 
-		expect(screen.getByLabelText('From')).toBeInTheDocument()
-		expect(screen.getByLabelText('To')).toBeInTheDocument()
+		expect(screen.getByLabelText('From')).toBeVisible()
+		expect(screen.getByLabelText('To')).toBeVisible()
 	})
 
 	it('should keep the date fields read only, so a typed date can never be silently discarded', () => {
@@ -172,45 +177,49 @@ describe('SearchExpensesFilters', () => {
 		expect(screen.getByLabelText('To')).toHaveAttribute('readonly')
 	})
 
-	it('should open the calendar when a date field is tapped', () => {
+	it('should open the calendar when a date field is tapped', async () => {
+		const user = userEvent.setup()
+
 		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
 
-		expect(document.querySelector('table')).not.toBeInTheDocument()
+		expect(screen.queryByRole('grid')).not.toBeInTheDocument()
 
-		fireEvent.click(screen.getByLabelText('From'))
+		await user.click(screen.getByLabelText('From'))
 
-		expect(document.querySelector('table')).toBeInTheDocument()
+		expect(screen.getByRole('grid')).toBeVisible()
 	})
 
-	it('should reach onSearch with a Date when a day is picked from the calendar', () => {
+	it('should reach onSearch with a Date when a day is picked from the calendar', async () => {
+		const user = userEvent.setup()
 		const onSearch = vi.fn()
 
 		render(<SearchExpensesFilters categories={categories} onSearch={onSearch} />)
 
-		fireEvent.click(screen.getByLabelText('From'))
-
-		const dayCells = document.querySelectorAll('table tbody td')
-		fireEvent.click(dayCells[15])
-
-		fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+		await user.click(screen.getByLabelText('From'))
+		await user.click(screen.getAllByRole('gridcell')[15])
+		await user.click(screen.getByRole('button', { name: 'Search' }))
 
 		expect(onSearch).toHaveBeenCalledTimes(1)
 		expect(onSearch.mock.calls[0][0].startDate).toBeInstanceOf(Date)
 	})
 
-	it('should disable the Search button and show a message when an amount is not a valid number', () => {
+	it('should disable the Search button and show a message when an amount is not a valid number', async () => {
+		const user = userEvent.setup()
+
 		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
 
-		fireEvent.change(screen.getByLabelText('Min amount'), { target: { value: 'abc' } })
+		await user.type(screen.getByLabelText('Min amount'), 'abc')
 
 		expect(screen.getByRole('button', { name: 'Search' })).toBeDisabled()
 		expect(screen.getByText('Amount must be a number using a decimal point or comma')).toBeVisible()
 	})
 
-	it('should keep the Search button enabled when the amount is a valid number', () => {
+	it('should keep the Search button enabled when the amount is a valid number', async () => {
+		const user = userEvent.setup()
+
 		render(<SearchExpensesFilters categories={categories} onSearch={vi.fn()} />)
 
-		fireEvent.change(screen.getByLabelText('Min amount'), { target: { value: '23,15' } })
+		await user.type(screen.getByLabelText('Min amount'), '23,15')
 
 		expect(screen.getByRole('button', { name: 'Search' })).not.toBeDisabled()
 		expect(screen.queryByText('Amount must be a number using a decimal point or comma')).not.toBeInTheDocument()

--- a/src/components/Expenses/SearchExpensesFilters/styles.css
+++ b/src/components/Expenses/SearchExpensesFilters/styles.css
@@ -1,9 +1,4 @@
-/*
- * The date inputs are read only on purpose, so the calendar is the only way a date gets in.
- * react-widgets styles any read only input with a "not allowed" cursor, which is misleading
- * here: tapping the field does something, it opens the calendar.
- */
-
+/* react-widgets sets "not allowed" on read only inputs, but tapping these opens the calendar */
 .search-expenses-filters .rw-input[readonly] {
 	cursor: pointer;
 }

--- a/src/components/Expenses/SearchExpensesFilters/styles.css
+++ b/src/components/Expenses/SearchExpensesFilters/styles.css
@@ -1,0 +1,9 @@
+/*
+ * The date inputs are read only on purpose, so the calendar is the only way a date gets in.
+ * react-widgets styles any read only input with a "not allowed" cursor, which is misleading
+ * here: tapping the field does something, it opens the calendar.
+ */
+
+.search-expenses-filters .rw-input[readonly] {
+	cursor: pointer;
+}

--- a/src/components/Expenses/SearchExpensesFilters/utils.js
+++ b/src/components/Expenses/SearchExpensesFilters/utils.js
@@ -1,0 +1,101 @@
+/**
+ * Check if a filter value has been filled in by the user.
+ * An empty string must never reach the API: the backend treats it as a provided
+ * value and its validation rejects it.
+ * @param {*} value
+ * @returns {boolean}
+ */
+const isFilled = (value) => value !== null && value !== undefined && value !== ''
+
+/**
+ * Parse an amount written by the user, accepting both decimal point and decimal comma
+ * @example
+ * 	parseAmount('23,15') // 23.15
+ * @param {string} value
+ * @returns {number|undefined} undefined when the value is empty or not a number
+ */
+const parseAmount = (value) => {
+	if (!isFilled(value) || value.trim() === '') {
+		return undefined
+	}
+
+	const parsed = Number(value.trim().replace(',', '.'))
+
+	return Number.isFinite(parsed) ? parsed : undefined
+}
+
+/**
+ * Get a copy of a date placed at the very beginning of its day
+ * @param {Date} date
+ * @returns {Date}
+ */
+const startOfDay = (date) => {
+	const result = new Date(date)
+	result.setHours(0, 0, 0, 0)
+	return result
+}
+
+/**
+ * Get a copy of a date placed at the very end of its day
+ * @param {Date} date
+ * @returns {Date}
+ */
+const endOfDay = (date) => {
+	const result = new Date(date)
+	result.setHours(23, 59, 59, 999)
+	return result
+}
+
+/**
+ * Build the variables of the searchExpenses query.
+ * Every filter left empty is omitted from the result: the backend accepts an absent
+ * argument, but rejects an empty string.
+ * @param {Object} filters
+ * @param {number} page
+ * @param {number} pageSize
+ * @returns {Object}
+ */
+const buildSearchVariables = (filters, page, pageSize) => {
+	const variables = {
+		page,
+		pageSize,
+		sortBy: filters.sortBy,
+		sortDirection: filters.sortDirection
+	}
+
+	if (isFilled(filters.category)) {
+		variables.category = filters.category
+	}
+
+	if (isFilled(filters.subcategory)) {
+		variables.subcategory = filters.subcategory
+	}
+
+	if (isFilled(filters.startDate)) {
+		variables.startDate = startOfDay(filters.startDate).toISOString()
+	}
+
+	if (isFilled(filters.endDate)) {
+		variables.endDate = endOfDay(filters.endDate).toISOString()
+	}
+
+	const minQuantity = parseAmount(filters.minQuantity)
+	const maxQuantity = parseAmount(filters.maxQuantity)
+
+	if (minQuantity !== undefined) {
+		variables.minQuantity = minQuantity
+	}
+
+	if (maxQuantity !== undefined) {
+		variables.maxQuantity = maxQuantity
+	}
+
+	return variables
+}
+
+export {
+	parseAmount,
+	startOfDay,
+	endOfDay,
+	buildSearchVariables
+}

--- a/src/components/Expenses/SearchExpensesFilters/utils.js
+++ b/src/components/Expenses/SearchExpensesFilters/utils.js
@@ -1,3 +1,5 @@
+import { getNameOfCategoryOrSubcategory } from '../utils'
+
 /**
  * Check if a filter value has been filled in by the user.
  * An empty string must never reach the API: the backend treats it as a provided
@@ -93,9 +95,82 @@ const buildSearchVariables = (filters, page, pageSize) => {
 	return variables
 }
 
+/**
+ * Check if the value written by the user for an amount field is valid.
+ * An empty or blank value is valid (an empty filter is valid). Otherwise, the value
+ * must parse to a finite number greater than or equal to zero: the backend rejects
+ * negative amounts.
+ * @param {string} value
+ * @returns {boolean}
+ */
+const isValidAmountInput = (value) => {
+	if (!isFilled(value) || value.trim() === '') {
+		return true
+	}
+
+	const parsed = Number(value.trim().replace(',', '.'))
+
+	return Number.isFinite(parsed) && parsed >= 0
+}
+
+/**
+ * Format a date as YYYY-MM-DD using local time, matching how the results table
+ * renders dates.
+ * @param {Date} date
+ * @returns {string}
+ */
+const formatDateAsLocalISO = (date) => {
+	const year = date.getFullYear()
+	const month = String(date.getMonth() + 1).padStart(2, '0')
+	const day = String(date.getDate()).padStart(2, '0')
+
+	return `${year}-${month}-${day}`
+}
+
+/**
+ * Build a human readable summary of the active filters, meant to be shown as the
+ * label of the collapsed filters header.
+ * @param {Object} filters
+ * @param {Array} categories
+ * @returns {string}
+ */
+const buildFiltersSummary = (filters, categories) => {
+	const parts = []
+
+	if (isFilled(filters.subcategory)) {
+		const categoryName = getNameOfCategoryOrSubcategory(filters.category, categories)
+		const subcategoryName = getNameOfCategoryOrSubcategory(filters.subcategory, categories)
+		parts.push(`${categoryName} - ${subcategoryName}`)
+	} else if (isFilled(filters.category)) {
+		parts.push(getNameOfCategoryOrSubcategory(filters.category, categories))
+	} else {
+		parts.push('All categories')
+	}
+
+	if (isFilled(filters.startDate) && isFilled(filters.endDate)) {
+		parts.push(`${formatDateAsLocalISO(filters.startDate)} to ${formatDateAsLocalISO(filters.endDate)}`)
+	} else if (isFilled(filters.startDate)) {
+		parts.push(`from ${formatDateAsLocalISO(filters.startDate)}`)
+	} else if (isFilled(filters.endDate)) {
+		parts.push(`until ${formatDateAsLocalISO(filters.endDate)}`)
+	}
+
+	if (isFilled(filters.minQuantity) && isFilled(filters.maxQuantity)) {
+		parts.push(`${filters.minQuantity} to ${filters.maxQuantity}`)
+	} else if (isFilled(filters.minQuantity)) {
+		parts.push(`from ${filters.minQuantity}`)
+	} else if (isFilled(filters.maxQuantity)) {
+		parts.push(`up to ${filters.maxQuantity}`)
+	}
+
+	return parts.join(' · ')
+}
+
 export {
 	parseAmount,
 	startOfDay,
 	endOfDay,
-	buildSearchVariables
+	buildSearchVariables,
+	isValidAmountInput,
+	buildFiltersSummary
 }

--- a/src/components/Expenses/SearchExpensesFilters/utils.test.js
+++ b/src/components/Expenses/SearchExpensesFilters/utils.test.js
@@ -1,0 +1,131 @@
+import { parseAmount, startOfDay, endOfDay, buildSearchVariables } from './utils'
+
+const emptyFilters = {
+	category: '',
+	subcategory: '',
+	startDate: null,
+	endDate: null,
+	minQuantity: '',
+	maxQuantity: '',
+	sortBy: 'date',
+	sortDirection: 'desc'
+}
+
+describe('parseAmount', () => {
+	it('should parse a value written with a decimal point', () => {
+		expect(parseAmount('23.15')).toBe(23.15)
+	})
+
+	it('should parse a value written with a decimal comma', () => {
+		expect(parseAmount('23,15')).toBe(23.15)
+	})
+
+	it('should parse zero as a valid amount', () => {
+		expect(parseAmount('0')).toBe(0)
+	})
+
+	it('should return undefined for an empty or blank value', () => {
+		expect(parseAmount('')).toBeUndefined()
+		expect(parseAmount('   ')).toBeUndefined()
+	})
+
+	it('should return undefined for a value that is not a number', () => {
+		expect(parseAmount('abc')).toBeUndefined()
+	})
+})
+
+describe('startOfDay and endOfDay', () => {
+	it('should move a date to the very beginning of its day', () => {
+		const result = startOfDay(new Date(2026, 1, 1, 17, 42, 13, 500))
+
+		expect(result.getFullYear()).toBe(2026)
+		expect(result.getMonth()).toBe(1)
+		expect(result.getDate()).toBe(1)
+		expect(result.getHours()).toBe(0)
+		expect(result.getMinutes()).toBe(0)
+		expect(result.getSeconds()).toBe(0)
+		expect(result.getMilliseconds()).toBe(0)
+	})
+
+	it('should move a date to the very end of its day', () => {
+		const result = endOfDay(new Date(2026, 3, 30, 8, 5, 0, 0))
+
+		expect(result.getDate()).toBe(30)
+		expect(result.getHours()).toBe(23)
+		expect(result.getMinutes()).toBe(59)
+		expect(result.getSeconds()).toBe(59)
+		expect(result.getMilliseconds()).toBe(999)
+	})
+
+	it('should not mutate the date received', () => {
+		const original = new Date(2026, 1, 1, 17, 42, 13, 500)
+
+		startOfDay(original)
+
+		expect(original.getHours()).toBe(17)
+	})
+})
+
+describe('buildSearchVariables', () => {
+	it('should always send page, pageSize and sorting', () => {
+		const variables = buildSearchVariables(emptyFilters, 2, 25)
+
+		expect(variables.page).toBe(2)
+		expect(variables.pageSize).toBe(25)
+		expect(variables.sortBy).toBe('date')
+		expect(variables.sortDirection).toBe('desc')
+	})
+
+	it('should omit every filter that is not filled in', () => {
+		const variables = buildSearchVariables(emptyFilters, 1, 25)
+
+		expect('category' in variables).toBe(false)
+		expect('subcategory' in variables).toBe(false)
+		expect('startDate' in variables).toBe(false)
+		expect('endDate' in variables).toBe(false)
+		expect('minQuantity' in variables).toBe(false)
+		expect('maxQuantity' in variables).toBe(false)
+	})
+
+	it('should send the identifiers of category and subcategory when they are selected', () => {
+		const filters = { ...emptyFilters, category: 'category-id-1', subcategory: 'subcategory-id-1' }
+
+		const variables = buildSearchVariables(filters, 1, 25)
+
+		expect(variables.category).toBe('category-id-1')
+		expect(variables.subcategory).toBe('subcategory-id-1')
+	})
+
+	it('should send the start date at the beginning of the day and the end date at the end of the day', () => {
+		const filters = { ...emptyFilters, startDate: new Date(2026, 1, 1), endDate: new Date(2026, 3, 30) }
+
+		const variables = buildSearchVariables(filters, 1, 25)
+
+		expect(variables.startDate).toBe('2026-01-31T23:00:00.000Z')
+		expect(variables.endDate).toBe('2026-04-30T21:59:59.999Z')
+	})
+
+	it('should send an amount of zero instead of dropping it', () => {
+		const filters = { ...emptyFilters, minQuantity: '0', maxQuantity: '0' }
+
+		const variables = buildSearchVariables(filters, 1, 25)
+
+		expect(variables.minQuantity).toBe(0)
+		expect(variables.maxQuantity).toBe(0)
+	})
+
+	it('should send the same value on both ends when searching an exact amount', () => {
+		const filters = { ...emptyFilters, minQuantity: '23,15', maxQuantity: '23,15' }
+
+		const variables = buildSearchVariables(filters, 1, 25)
+
+		expect(variables.minQuantity).toBe(23.15)
+		expect(variables.maxQuantity).toBe(23.15)
+	})
+
+	it('should never send an empty string, because the backend rejects it', () => {
+		const variables = buildSearchVariables(emptyFilters, 1, 25)
+
+		expect(Object.values(variables)).not.toContain('')
+	})
+})

--- a/src/components/Expenses/SearchExpensesFilters/utils.test.js
+++ b/src/components/Expenses/SearchExpensesFilters/utils.test.js
@@ -1,4 +1,21 @@
-import { parseAmount, startOfDay, endOfDay, buildSearchVariables } from './utils'
+import { parseAmount, startOfDay, endOfDay, buildSearchVariables, isValidAmountInput, buildFiltersSummary } from './utils'
+
+const categories = [
+	{
+		_id: 'category-id-1',
+		name: 'Private vehicles',
+		uuid: 'category-uuid-1',
+		subcategories: [
+			{ _id: 'subcategory-id-1', name: 'Fuel', uuid: 'subcategory-uuid-1' }
+		]
+	},
+	{
+		_id: 'category-id-2',
+		name: 'Home',
+		uuid: 'category-uuid-2',
+		subcategories: []
+	}
+]
 
 const emptyFilters = {
 	category: '',
@@ -127,5 +144,118 @@ describe('buildSearchVariables', () => {
 		const variables = buildSearchVariables(emptyFilters, 1, 25)
 
 		expect(Object.values(variables)).not.toContain('')
+	})
+})
+
+describe('isValidAmountInput', () => {
+	it('should accept an empty value', () => {
+		expect(isValidAmountInput('')).toBe(true)
+	})
+
+	it('should accept a blank value', () => {
+		expect(isValidAmountInput('   ')).toBe(true)
+	})
+
+	it('should accept a value written with a decimal point', () => {
+		expect(isValidAmountInput('23.15')).toBe(true)
+	})
+
+	it('should accept a value written with a decimal comma', () => {
+		expect(isValidAmountInput('23,15')).toBe(true)
+	})
+
+	it('should accept zero', () => {
+		expect(isValidAmountInput('0')).toBe(true)
+	})
+
+	it('should reject a negative number', () => {
+		expect(isValidAmountInput('-5')).toBe(false)
+	})
+
+	it('should reject a value with more than one decimal separator', () => {
+		expect(isValidAmountInput('1.234,56')).toBe(false)
+	})
+
+	it('should reject a value with a stray character', () => {
+		expect(isValidAmountInput('12€')).toBe(false)
+	})
+
+	it('should reject a value that is not a number', () => {
+		expect(isValidAmountInput('abc')).toBe(false)
+	})
+})
+
+describe('buildFiltersSummary', () => {
+	it('should say "All categories" when no category is selected', () => {
+		expect(buildFiltersSummary(emptyFilters, categories)).toBe('All categories')
+	})
+
+	it('should include the category name when a category is selected', () => {
+		const filters = { ...emptyFilters, category: 'category-id-1' }
+
+		expect(buildFiltersSummary(filters, categories)).toBe('Private vehicles')
+	})
+
+	it('should include the category and subcategory names when a subcategory is selected', () => {
+		const filters = { ...emptyFilters, category: 'category-id-1', subcategory: 'subcategory-id-1' }
+
+		expect(buildFiltersSummary(filters, categories)).toBe('Private vehicles - Fuel')
+	})
+
+	it('should omit the date part when neither date is set', () => {
+		expect(buildFiltersSummary(emptyFilters, categories)).not.toContain('to')
+	})
+
+	it('should describe a date range when both dates are set', () => {
+		const filters = { ...emptyFilters, startDate: new Date(2026, 0, 1), endDate: new Date(2026, 5, 30) }
+
+		expect(buildFiltersSummary(filters, categories)).toBe('All categories · 2026-01-01 to 2026-06-30')
+	})
+
+	it('should describe an open-ended start date', () => {
+		const filters = { ...emptyFilters, startDate: new Date(2026, 0, 1) }
+
+		expect(buildFiltersSummary(filters, categories)).toBe('All categories · from 2026-01-01')
+	})
+
+	it('should describe an open-ended end date', () => {
+		const filters = { ...emptyFilters, endDate: new Date(2026, 5, 30) }
+
+		expect(buildFiltersSummary(filters, categories)).toBe('All categories · until 2026-06-30')
+	})
+
+	it('should omit the amount part when neither amount is set', () => {
+		expect(buildFiltersSummary(emptyFilters, categories)).toBe('All categories')
+	})
+
+	it('should describe an amount range when both amounts are set, using the raw strings typed', () => {
+		const filters = { ...emptyFilters, minQuantity: '10', maxQuantity: '20,50' }
+
+		expect(buildFiltersSummary(filters, categories)).toBe('All categories · 10 to 20,50')
+	})
+
+	it('should describe an open-ended minimum amount', () => {
+		const filters = { ...emptyFilters, minQuantity: '10' }
+
+		expect(buildFiltersSummary(filters, categories)).toBe('All categories · from 10')
+	})
+
+	it('should describe an open-ended maximum amount', () => {
+		const filters = { ...emptyFilters, maxQuantity: '20,50' }
+
+		expect(buildFiltersSummary(filters, categories)).toBe('All categories · up to 20,50')
+	})
+
+	it('should join category, date and amount parts together', () => {
+		const filters = {
+			...emptyFilters,
+			category: 'category-id-1',
+			startDate: new Date(2026, 0, 1),
+			endDate: new Date(2026, 5, 30),
+			minQuantity: '10',
+			maxQuantity: '20,50'
+		}
+
+		expect(buildFiltersSummary(filters, categories)).toBe('Private vehicles · 2026-01-01 to 2026-06-30 · 10 to 20,50')
 	})
 })

--- a/src/components/Expenses/SearchExpensesResults/index.js
+++ b/src/components/Expenses/SearchExpensesResults/index.js
@@ -40,7 +40,7 @@ export const SearchExpensesResults = ({ searchResult, categories, onChangePage }
 
 	return (
 		<section>
-			<div className="card bg-dark border-info mb-4">
+			<section className="card bg-dark border-info mb-4" aria-label="Search summary">
 				<div className="card-body">
 					<p className="text-muted mb-1">Total spent</p>
 					<p className="h3 text-info">{totalSum} {currencyISO}</p>
@@ -60,7 +60,7 @@ export const SearchExpensesResults = ({ searchResult, categories, onChangePage }
 						}
 					</ul>
 				</div>
-			</div>
+			</section>
 
 			<div className="table-responsive">
 				<table className="table table-dark table-hover table-sm align-middle">

--- a/src/components/Expenses/SearchExpensesResults/index.js
+++ b/src/components/Expenses/SearchExpensesResults/index.js
@@ -63,21 +63,21 @@ export const SearchExpensesResults = ({ searchResult, categories, onChangePage }
 			</div>
 
 			<div className="table-responsive">
-				<table className="table table-dark table-hover">
+				<table className="table table-dark table-hover table-sm align-middle">
 					<thead>
 						<tr className="table-info text-dark">
-							<th scope="col">Date</th>
+							<th scope="col" className="text-nowrap">Date</th>
 							<th scope="col">Category &amp; subcategory</th>
-							<th scope="col">Quantity</th>
+							<th scope="col" className="text-nowrap">Quantity</th>
 						</tr>
 					</thead>
 					<tbody>
 						{
 							expenses.map(expense => (
 								<tr key={expense.uuid}>
-									<td>{parseUnixTimestamp(expense.date).substring(0, DATE_LENGTH)}</td>
+									<td className="text-nowrap">{parseUnixTimestamp(expense.date).substring(0, DATE_LENGTH)}</td>
 									<td>{getFullName(expense.category, expense.subcategory, categories)}</td>
-									<td>{expense.quantity} {expense.currencyISO}</td>
+									<td className="text-nowrap">{expense.quantity} {expense.currencyISO}</td>
 								</tr>
 							))
 						}

--- a/src/components/Expenses/SearchExpensesResults/index.js
+++ b/src/components/Expenses/SearchExpensesResults/index.js
@@ -16,7 +16,7 @@ const DATE_LENGTH = 10
  * @returns {string}
  */
 const getFullName = (category, subcategory, categories) => {
-	const nameOfCategory = getNameOfCategoryOrSubcategory(category, categories)
+	const nameOfCategory = getNameOfCategoryOrSubcategory(category, categories) ?? ''
 	const nameOfSubcategory = getNameOfCategoryOrSubcategory(subcategory, categories)
 
 	return `${nameOfCategory}${(nameOfSubcategory) ? ` - ${nameOfSubcategory}` : ''}`

--- a/src/components/Expenses/SearchExpensesResults/index.js
+++ b/src/components/Expenses/SearchExpensesResults/index.js
@@ -22,6 +22,15 @@ const getFullName = (category, subcategory, categories) => {
 	return `${nameOfCategory}${(nameOfSubcategory) ? ` - ${nameOfSubcategory}` : ''}`
 }
 
+/**
+ * Get a number of expenses with its noun, so the figure is never displayed unlabelled
+ * @example
+ * 	getExpensesLabel(1) // '1 expense'
+ * @param {number} count
+ * @returns {string}
+ */
+const getExpensesLabel = (count) => `${count} ${(count === 1) ? 'expense' : 'expenses'}`
+
 export const SearchExpensesResults = ({ searchResult, categories, onChangePage }) => {
 	const { expenses, pagination, totalSum, currencyISO, breakdown } = searchResult
 
@@ -35,14 +44,17 @@ export const SearchExpensesResults = ({ searchResult, categories, onChangePage }
 				<div className="card-body">
 					<p className="text-muted mb-1">Total spent</p>
 					<p className="h3 text-info">{totalSum} {currencyISO}</p>
-					<p className="text-muted">{pagination.totalCount} expenses</p>
+					<p className="text-muted">{getExpensesLabel(pagination.totalCount)}</p>
 
 					<ul className="list-unstyled mb-0">
 						{
 							breakdown.map(entry => (
-								<li key={`${entry.category}-${entry.subcategory}`} className="d-flex justify-content-between text-light border-top border-secondary py-1">
-									<span>{getFullName(entry.category, entry.subcategory, categories)} · {entry.count}</span>
-									<span>{entry.sum} {currencyISO}</span>
+								<li key={`${entry.category}-${entry.subcategory}`} className="text-light border-top border-secondary py-2">
+									<p className="mb-1">{getFullName(entry.category, entry.subcategory, categories)}</p>
+									<div className="d-flex justify-content-between small">
+										<span className="text-muted">{getExpensesLabel(entry.count)}</span>
+										<span>{entry.sum} {currencyISO}</span>
+									</div>
 								</li>
 							))
 						}

--- a/src/components/Expenses/SearchExpensesResults/index.js
+++ b/src/components/Expenses/SearchExpensesResults/index.js
@@ -1,0 +1,124 @@
+import PropTypes from 'prop-types'
+
+import { parseUnixTimestamp } from '../../../utils/utils'
+import { getNameOfCategoryOrSubcategory } from '../utils'
+
+import { ErrorAlert } from '../../ErrorAlert'
+import { PaginateNavbar } from '../../PaginateNavbar'
+
+const DATE_LENGTH = 10
+
+/**
+ * Get the displayable name of a category and its subcategory
+ * @param {string} category
+ * @param {string|null} subcategory
+ * @param {Array} categories
+ * @returns {string}
+ */
+const getFullName = (category, subcategory, categories) => {
+	const nameOfCategory = getNameOfCategoryOrSubcategory(category, categories)
+	const nameOfSubcategory = getNameOfCategoryOrSubcategory(subcategory, categories)
+
+	return `${nameOfCategory}${(nameOfSubcategory) ? ` - ${nameOfSubcategory}` : ''}`
+}
+
+export const SearchExpensesResults = ({ searchResult, categories, onChangePage }) => {
+	const { expenses, pagination, totalSum, currencyISO, breakdown } = searchResult
+
+	if (!expenses.length) {
+		return <ErrorAlert errorMessage='No expenses found' />
+	}
+
+	return (
+		<section>
+			<div className="card bg-dark border-info mb-4">
+				<div className="card-body">
+					<p className="text-muted mb-1">Total spent</p>
+					<p className="h3 text-info">{totalSum} {currencyISO}</p>
+					<p className="text-muted">{pagination.totalCount} expenses</p>
+
+					<ul className="list-unstyled mb-0">
+						{
+							breakdown.map(entry => (
+								<li key={`${entry.category}-${entry.subcategory}`} className="d-flex justify-content-between text-light border-top border-secondary py-1">
+									<span>{getFullName(entry.category, entry.subcategory, categories)} · {entry.count}</span>
+									<span>{entry.sum} {currencyISO}</span>
+								</li>
+							))
+						}
+					</ul>
+				</div>
+			</div>
+
+			<div className="table-responsive">
+				<table className="table table-dark table-hover">
+					<thead>
+						<tr className="table-info text-dark">
+							<th scope="col">Date</th>
+							<th scope="col">Category &amp; subcategory</th>
+							<th scope="col">Quantity</th>
+						</tr>
+					</thead>
+					<tbody>
+						{
+							expenses.map(expense => (
+								<tr key={expense.uuid}>
+									<td>{parseUnixTimestamp(expense.date).substring(0, DATE_LENGTH)}</td>
+									<td>{getFullName(expense.category, expense.subcategory, categories)}</td>
+									<td>{expense.quantity} {expense.currencyISO}</td>
+								</tr>
+							))
+						}
+					</tbody>
+				</table>
+			</div>
+
+			<PaginateNavbar currentPage={pagination.currentPage} totalPages={pagination.totalPages} onChangePage={onChangePage} />
+		</section>
+	)
+}
+
+SearchExpensesResults.propTypes = {
+	searchResult: PropTypes.shape({
+		expenses: PropTypes.arrayOf(
+			PropTypes.shape({
+				date: PropTypes.string.isRequired,
+				uuid: PropTypes.string.isRequired,
+				category: PropTypes.string.isRequired,
+				subcategory: PropTypes.string,
+				quantity: PropTypes.number.isRequired,
+				currencyISO: PropTypes.string.isRequired
+			})
+		).isRequired,
+		pagination: PropTypes.shape({
+			currentPage: PropTypes.number.isRequired,
+			totalPages: PropTypes.number.isRequired,
+			totalCount: PropTypes.number.isRequired
+		}).isRequired,
+		totalSum: PropTypes.number.isRequired,
+		currencyISO: PropTypes.string.isRequired,
+		breakdown: PropTypes.arrayOf(
+			PropTypes.shape({
+				category: PropTypes.string.isRequired,
+				subcategory: PropTypes.string,
+				sum: PropTypes.number.isRequired,
+				count: PropTypes.number.isRequired
+			})
+		).isRequired
+	}).isRequired,
+	categories: PropTypes.arrayOf(
+		PropTypes.shape({
+			_id: PropTypes.string.isRequired,
+			name: PropTypes.string.isRequired,
+			subcategories: PropTypes.arrayOf(
+				PropTypes.shape({
+					_id: PropTypes.string.isRequired,
+					name: PropTypes.string.isRequired,
+					uuid: PropTypes.string.isRequired
+				})
+			),
+			uuid: PropTypes.string.isRequired
+		})
+	).isRequired,
+	onChangePage: PropTypes.func.isRequired
+}

--- a/src/components/Expenses/SearchExpensesResults/index.test.js
+++ b/src/components/Expenses/SearchExpensesResults/index.test.js
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react'
+
+import { SearchExpensesResults } from './'
+
+const categories = [
+	{
+		_id: 'category-id-1',
+		name: 'Private vehicles',
+		uuid: 'category-uuid-1',
+		subcategories: [
+			{ _id: 'subcategory-id-1', name: 'Fuel', uuid: 'subcategory-uuid-1' }
+		]
+	},
+	{
+		_id: 'category-id-2',
+		name: 'Groceries, personal care products',
+		uuid: 'category-uuid-2',
+		subcategories: []
+	}
+]
+
+const firstOfFebruary = String(new Date(2026, 1, 1).getTime())
+
+const searchResult = {
+	expenses: [
+		{
+			uuid: 'expense-uuid-1',
+			date: firstOfFebruary,
+			category: 'category-id-1',
+			subcategory: 'subcategory-id-1',
+			quantity: 64.2,
+			currencyISO: 'EUR'
+		},
+		{
+			uuid: 'expense-uuid-2',
+			date: firstOfFebruary,
+			category: 'category-id-2',
+			subcategory: null,
+			quantity: 23.15,
+			currencyISO: 'EUR'
+		}
+	],
+	pagination: { currentPage: 1, totalPages: 3, totalCount: 37 },
+	totalSum: 1284.6,
+	currencyISO: 'EUR',
+	breakdown: [
+		{ category: 'category-id-1', subcategory: 'subcategory-id-1', sum: 612.4, count: 18 },
+		{ category: 'category-id-2', subcategory: null, sum: 672.2, count: 19 }
+	]
+}
+
+describe('SearchExpensesResults', () => {
+	it('should display the total amount and the number of expenses', () => {
+		render(<SearchExpensesResults searchResult={searchResult} categories={categories} onChangePage={vi.fn()} />)
+
+		expect(screen.getByText('1284.6 EUR')).toBeInTheDocument()
+		expect(screen.getByText('37 expenses')).toBeInTheDocument()
+	})
+
+	it('should display one breakdown row per entry, with resolved names', () => {
+		render(<SearchExpensesResults searchResult={searchResult} categories={categories} onChangePage={vi.fn()} />)
+
+		expect(screen.getByText('Private vehicles - Fuel · 18')).toBeInTheDocument()
+		expect(screen.getByText('Groceries, personal care products · 19')).toBeInTheDocument()
+	})
+
+	it('should display one table row per expense, with the date and the resolved names', () => {
+		render(<SearchExpensesResults searchResult={searchResult} categories={categories} onChangePage={vi.fn()} />)
+
+		expect(screen.getAllByText('2026-02-01')).toHaveLength(2)
+		expect(screen.getByText('64.2 EUR')).toBeInTheDocument()
+		expect(screen.getByText('23.15 EUR')).toBeInTheDocument()
+	})
+
+	it('should not offer any action to delete an expense', () => {
+		render(<SearchExpensesResults searchResult={searchResult} categories={categories} onChangePage={vi.fn()} />)
+
+		expect(screen.queryByText('Delete')).not.toBeInTheDocument()
+	})
+
+	it('should display an alert when the search returns no expenses', () => {
+		const emptyResult = {
+			...searchResult,
+			expenses: [],
+			pagination: { currentPage: 1, totalPages: 0, totalCount: 0 },
+			totalSum: 0,
+			breakdown: []
+		}
+
+		render(<SearchExpensesResults searchResult={emptyResult} categories={categories} onChangePage={vi.fn()} />)
+
+		expect(screen.getByText('No expenses found')).toBeInTheDocument()
+	})
+})

--- a/src/components/Expenses/SearchExpensesResults/index.test.js
+++ b/src/components/Expenses/SearchExpensesResults/index.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 
 import { SearchExpensesResults } from './'
 
@@ -57,11 +57,16 @@ describe('SearchExpensesResults', () => {
 		expect(screen.getByText('37 expenses')).toBeInTheDocument()
 	})
 
-	it('should display one breakdown row per entry, with resolved names', () => {
+	it('should display the breakdown rows in the order returned by the backend, with resolved names', () => {
 		render(<SearchExpensesResults searchResult={searchResult} categories={categories} onChangePage={vi.fn()} />)
 
-		expect(screen.getByText('Private vehicles - Fuel · 18')).toBeInTheDocument()
-		expect(screen.getByText('Groceries, personal care products · 19')).toBeInTheDocument()
+		const totalCard = screen.getByText('Total spent').closest('.card')
+		const items = within(totalCard).getAllByRole('listitem')
+
+		expect(items.map(item => item.textContent)).toEqual([
+			'Private vehicles - Fuel · 18612.4 EUR',
+			'Groceries, personal care products · 19672.2 EUR'
+		])
 	})
 
 	it('should display one table row per expense, with the date and the resolved names', () => {
@@ -70,6 +75,27 @@ describe('SearchExpensesResults', () => {
 		expect(screen.getAllByText('2026-02-01')).toHaveLength(2)
 		expect(screen.getByText('64.2 EUR')).toBeInTheDocument()
 		expect(screen.getByText('23.15 EUR')).toBeInTheDocument()
+	})
+
+	it('should render nothing instead of the literal "null" when a category cannot be resolved', () => {
+		const resultWithDeletedCategory = {
+			...searchResult,
+			expenses: [
+				{
+					uuid: 'expense-uuid-3',
+					date: firstOfFebruary,
+					category: 'deleted-category-id',
+					subcategory: null,
+					quantity: 10,
+					currencyISO: 'EUR'
+				}
+			]
+		}
+
+		render(<SearchExpensesResults searchResult={resultWithDeletedCategory} categories={categories} onChangePage={vi.fn()} />)
+
+		expect(screen.getByRole('cell', { name: '' })).toBeInTheDocument()
+		expect(screen.queryByText('null')).not.toBeInTheDocument()
 	})
 
 	it('should not offer any action to delete an expense', () => {

--- a/src/components/Expenses/SearchExpensesResults/index.test.js
+++ b/src/components/Expenses/SearchExpensesResults/index.test.js
@@ -135,6 +135,6 @@ describe('SearchExpensesResults', () => {
 
 		render(<SearchExpensesResults searchResult={emptyResult} categories={categories} onChangePage={vi.fn()} />)
 
-		expect(screen.getByText('No expenses found')).toBeInTheDocument()
+		expect(screen.getByText('No expenses found')).toBeVisible()
 	})
 })

--- a/src/components/Expenses/SearchExpensesResults/index.test.js
+++ b/src/components/Expenses/SearchExpensesResults/index.test.js
@@ -53,25 +53,19 @@ describe('SearchExpensesResults', () => {
 	it('should display the total amount and the number of expenses', () => {
 		render(<SearchExpensesResults searchResult={searchResult} categories={categories} onChangePage={vi.fn()} />)
 
-		expect(screen.getByText('1284.6 EUR')).toBeInTheDocument()
-		expect(screen.getByText('37 expenses')).toBeInTheDocument()
+		expect(screen.getByText('1284.6 EUR')).toBeVisible()
+		expect(screen.getByText('37 expenses')).toBeVisible()
 	})
 
 	it('should display the breakdown rows in the order returned by the backend, with resolved names', () => {
 		render(<SearchExpensesResults searchResult={searchResult} categories={categories} onChangePage={vi.fn()} />)
 
-		const totalCard = screen.getByText('Total spent').closest('.card')
-		const items = within(totalCard).getAllByRole('listitem')
+		const summary = screen.getByRole('region', { name: 'Search summary' })
+		const items = within(summary).getAllByRole('listitem')
 
-		expect(items.map(item => item.querySelector('p').textContent)).toEqual([
-			'Private vehicles - Fuel',
-			'Groceries, personal care products'
-		])
-
-		expect(within(items[0]).getByText('18 expenses')).toBeInTheDocument()
-		expect(within(items[0]).getByText('612.4 EUR')).toBeInTheDocument()
-		expect(within(items[1]).getByText('19 expenses')).toBeInTheDocument()
-		expect(within(items[1]).getByText('672.2 EUR')).toBeInTheDocument()
+		expect(items).toHaveLength(2)
+		expect(items[0]).toHaveTextContent(/^Private vehicles - Fuel18 expenses612\.4 EUR$/)
+		expect(items[1]).toHaveTextContent(/^Groceries, personal care products19 expenses672\.2 EUR$/)
 	})
 
 	it('should label a single expense in the singular', () => {
@@ -93,8 +87,8 @@ describe('SearchExpensesResults', () => {
 		render(<SearchExpensesResults searchResult={searchResult} categories={categories} onChangePage={vi.fn()} />)
 
 		expect(screen.getAllByText('2026-02-01')).toHaveLength(2)
-		expect(screen.getByText('64.2 EUR')).toBeInTheDocument()
-		expect(screen.getByText('23.15 EUR')).toBeInTheDocument()
+		expect(screen.getByText('64.2 EUR')).toBeVisible()
+		expect(screen.getByText('23.15 EUR')).toBeVisible()
 	})
 
 	it('should render nothing instead of the literal "null" when a category cannot be resolved', () => {
@@ -114,7 +108,7 @@ describe('SearchExpensesResults', () => {
 
 		render(<SearchExpensesResults searchResult={resultWithDeletedCategory} categories={categories} onChangePage={vi.fn()} />)
 
-		expect(screen.getByRole('cell', { name: '' })).toBeInTheDocument()
+		expect(screen.getByRole('cell', { name: '' })).toBeVisible()
 		expect(screen.queryByText('null')).not.toBeInTheDocument()
 	})
 

--- a/src/components/Expenses/SearchExpensesResults/index.test.js
+++ b/src/components/Expenses/SearchExpensesResults/index.test.js
@@ -63,10 +63,30 @@ describe('SearchExpensesResults', () => {
 		const totalCard = screen.getByText('Total spent').closest('.card')
 		const items = within(totalCard).getAllByRole('listitem')
 
-		expect(items.map(item => item.textContent)).toEqual([
-			'Private vehicles - Fuel · 18612.4 EUR',
-			'Groceries, personal care products · 19672.2 EUR'
+		expect(items.map(item => item.querySelector('p').textContent)).toEqual([
+			'Private vehicles - Fuel',
+			'Groceries, personal care products'
 		])
+
+		expect(within(items[0]).getByText('18 expenses')).toBeInTheDocument()
+		expect(within(items[0]).getByText('612.4 EUR')).toBeInTheDocument()
+		expect(within(items[1]).getByText('19 expenses')).toBeInTheDocument()
+		expect(within(items[1]).getByText('672.2 EUR')).toBeInTheDocument()
+	})
+
+	it('should label a single expense in the singular', () => {
+		const singleExpenseResult = {
+			...searchResult,
+			pagination: { currentPage: 1, totalPages: 1, totalCount: 1 },
+			breakdown: [
+				{ category: 'category-id-1', subcategory: 'subcategory-id-1', sum: 64.2, count: 1 }
+			]
+		}
+
+		render(<SearchExpensesResults searchResult={singleExpenseResult} categories={categories} onChangePage={vi.fn()} />)
+
+		expect(screen.getAllByText('1 expense')).toHaveLength(2)
+		expect(screen.queryByText('1 expenses')).not.toBeInTheDocument()
 	})
 
 	it('should display one table row per expense, with the date and the resolved names', () => {

--- a/src/components/NavBar/ExpensesDropdown.js
+++ b/src/components/NavBar/ExpensesDropdown.js
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 
-import { BsCreditCard2Back, BsCartPlus, BsBarChart, BsListUl, BsCalendarCheck, BsCalendar3 } from 'react-icons/bs'
+import { BsCreditCard2Back, BsCartPlus, BsBarChart, BsListUl, BsCalendarCheck, BsCalendar3, BsSearch } from 'react-icons/bs'
 
 
 export const ExpensesDropdown = () => {
@@ -40,6 +40,11 @@ export const ExpensesDropdown = () => {
 				<li>
 					<Link className="dropdown-item py-3" to='/expenses-analysis'>
 						<BsCalendarCheck size='24px' title='Monthly spending breakdown' /><span className="ms-3">Monthly spending breakdown</span>
+					</Link>
+				</li>
+				<li>
+					<Link className="dropdown-item py-3" to='/search-expenses'>
+						<BsSearch size='24px' title='Search spendings' /><span className="ms-3">Search spendings</span>
 					</Link>
 				</li>
 			</ul>

--- a/src/gql/queries/expenses.js
+++ b/src/gql/queries/expenses.js
@@ -140,3 +140,38 @@ query GetExpensesMonthlyAverage($excludedCategoryTypes: [CategoryType!]) {
 }
 ${EXPENSES_MONTHLY_AVERAGE_FIELDS}
 `
+
+export const SEARCH_EXPENSES = gql`
+query SearchExpenses($category: ID, $subcategory: ID, $startDate: String, $endDate: String, $minQuantity: Float, $maxQuantity: Float, $sortBy: ExpenseSortField, $sortDirection: SortDirection, $page: Int!, $pageSize: Int!) {
+	searchExpenses(
+		category: $category
+		subcategory: $subcategory
+		startDate: $startDate
+		endDate: $endDate
+		minQuantity: $minQuantity
+		maxQuantity: $maxQuantity
+		sortBy: $sortBy
+		sortDirection: $sortDirection
+		page: $page
+		pageSize: $pageSize
+	) {
+		expenses {
+			...ExpenseFields
+		}
+		pagination {
+			currentPage
+			totalPages
+			totalCount
+		}
+		totalSum
+		currencyISO
+		breakdown {
+			category
+			subcategory
+			sum
+			count
+		}
+	}
+}
+${EXPENSE_FIELDS}
+`

--- a/src/pages/Expenses/SearchExpenses.js
+++ b/src/pages/Expenses/SearchExpenses.js
@@ -1,0 +1,17 @@
+import { Fragment } from 'react'
+
+import { PageTitle } from '../../components/PageTitle'
+import { GetSearchExpenses } from '../../components/Expenses/GetSearchExpenses'
+
+const SearchExpenses = () => {
+	return (
+		<Fragment>
+			<PageTitle text='Spending search' />
+			<GetSearchExpenses />
+		</Fragment>
+	)
+}
+
+SearchExpenses.displayName = 'SearchExpenses'
+
+export default SearchExpenses

--- a/src/utils/dateLocalizer.js
+++ b/src/utils/dateLocalizer.js
@@ -2,12 +2,8 @@ import Moment from 'moment'
 import momentLocalizer from 'react-widgets-moment'
 
 /**
- * react-widgets needs a date localizer configured once, before any of its date components render.
- * Importing this module performs that setup, and module caching keeps it to a single execution.
- *
- * It lives here rather than in each component because `Moment.locale` mutates a global: with more
- * than one copy of this configuration, the last one to run would win, and the first day of the week
- * would depend on render order.
+ * Importing this module configures the react-widgets date localizer. It has no exports: import it
+ * for the side effect, once, from any component rendering a react-widgets date component.
  */
 Moment.locale('en', {
 	week: {

--- a/src/utils/dateLocalizer.js
+++ b/src/utils/dateLocalizer.js
@@ -1,0 +1,18 @@
+import Moment from 'moment'
+import momentLocalizer from 'react-widgets-moment'
+
+/**
+ * react-widgets needs a date localizer configured once, before any of its date components render.
+ * Importing this module performs that setup, and module caching keeps it to a single execution.
+ *
+ * It lives here rather than in each component because `Moment.locale` mutates a global: with more
+ * than one copy of this configuration, the last one to run would win, and the first day of the week
+ * would depend on render order.
+ */
+Moment.locale('en', {
+	week: {
+		dow: 1 // Monday is the first day of the week.
+	}
+})
+
+momentLocalizer()


### PR DESCRIPTION
Adds a `/search-expenses` page: a single search form with combinable filters over the whole expense history, plus a totals summary and a paginated table of the matching expenses.

It replaces five questions that the current screens cannot answer, all as combinations of the same filters:

| Question | Filters |
|---|---|
| Total spent on *Private vehicles* over the last 6 months, broken down by subcategory | category + date range |
| The most expensive *Electricity bill* of the last year | category + subcategory + date range + sort by amount |
| Which expense was 23.15 €, and what is it? | amount range, no category |
| Total spent on *Travels & holidays* between two dates | category + date range |
| Every expense of a category, newest first | category + sort by date |

## Backend dependency

This consumes the `searchExpenses` query, now merged on `didibudget-backend` master. The agreed contract lives there, in `docs/superpowers/specs/2026-07-25-search-expenses-backend.md`. Two of its rules shape most of the frontend code:

- A filter the user left empty is **omitted** from the variables. The backend accepts an absent argument or an explicit `null`, but an empty string reaches its validation and returns a `UserInputError` — and an empty string is exactly what a `<select>` with a blank option produces.
- `0` is a valid amount and is falsy, so no filter value is ever tested with a bare `if`.

## Verified against the running backend

Checked by hand against a real database, not just mocks:

- **Inclusive end of range**, with a positive and a negative control: `To = 2026-07-08` returns 3 expenses totalling 92.35 €; `To = 2026-07-07` returns 2 totalling 67.79 €. The difference is exactly the expense dated on the 8th.
- **A search with no filters at all** returns the full history rather than a validation error — the check that validates the whole omit-empty-keys design.
- **The arithmetic adds up**: `totalSum` 19971.39 equals the sum of the 41 breakdown entries, and `totalCount` 4736 equals the sum of their counts.
- `totalSum` arrives rounded to two decimals, so no float artifacts reach the screen.
- **Pagination is continuous**: page 1 ends on 2026-05-13, page 2 starts on 2026-05-12, no repeats and no gaps, and the summary does not change between pages.
- Amount bounds are inclusive; an exact amount typed with a decimal comma (`23,56`) returns the single matching expense.
- The route is behind `RequireAuth`: an unauthenticated visit lands on `/login`.

## Notes for review

- The date range is **inclusive at both ends**, unlike the existing `getExpensesBetweenDates`. The frontend sends the start at `00:00:00.000` and the end at `23:59:59.999`. `getExpensesBetweenDates` is untouched.
- The aggregates are computed by the backend over the **whole** filtered set, so the summary does not change while paging.
- `breakdown` arrives already ordered and is rendered in the order received; a test asserts the order so a future `.sort()` cannot slip in unnoticed.
- The search runs on the Search button, not on keystroke, hence `useLazyQuery`.
- **The date fields are read only**: the calendar is the only way a date gets in, and tapping the field opens it. Typed input used to be discarded on submit, so the search silently ran without the date filter. Dates display as `YYYY-MM-DD`, matching the results table.
- An amount that is not a valid number disables the Search button and says why, rather than being dropped and returning a total for the entire history.
- 90% of this app's traffic is mobile: the filter form collapses after a search into a header summarizing the active filters, and the results table scrolls horizontally like `ListOfExpenses` rather than becoming a card list.
- Form controls use plain Bootstrap classes, like every other form in the app.
- The results table has **no delete action**. This page is read-only; deleting stays in *Spending list*.

## Checked at 390 px, on the device this app is actually used on

- The page never scrolls sideways, and the results table fits without horizontal dragging.
- `From` and `To` stack instead of sharing a row.
- The filter form collapses after a search into a header naming the active filters.
- The breakdown reads as name, then count and amount on a second line, so the count is never a bare unlabelled number.
- The date and the amount no longer wrap mid-value in the results table. That alone took a typical row from 65 px to 33 px, doubling how many expenses fit on screen.

## Tests

28 files, 210 tests passing (161 before this branch); `npm run lint` clean.
