### PR TITLE
Replace fireEvent with userEvent and correct toBeInTheDocument uses

### DIFF
--- a/src/components/DidibudgetLogo/index.test.js
+++ b/src/components/DidibudgetLogo/index.test.js
@@ -10,7 +10,7 @@ describe('DidibudgetLogo', () => {
 
 		const svg = screen.getByRole('img', { name: /^didibudget$/i })
 
-		expect(svg).toBeInTheDocument()
+		expect(svg).toBeVisible()
 	})
 
 	it('should be an accessible SVG with a title received by props', () => {
@@ -18,6 +18,6 @@ describe('DidibudgetLogo', () => {
 
 		const svg = screen.getByRole('img', { name: /^This is an accessible title$/i })
 
-		expect(svg).toBeInTheDocument()
+		expect(svg).toBeVisible()
 	})
 })

--- a/src/components/Expenses/GetSearchExpenses.test.js
+++ b/src/components/Expenses/GetSearchExpenses.test.js
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MockedProvider } from '@apollo/client/testing'
 
 import { GetSearchExpenses } from './GetSearchExpenses'
@@ -126,28 +127,32 @@ describe('GetSearchExpenses', () => {
 	})
 
 	it('should run the search with the variables built from the filters and display the results', async () => {
+		const user = userEvent.setup()
+
 		render(
 			<MockedProvider mocks={[categoriesMock, searchExpensesPage1Mock]} addTypename={false}>
 				<GetSearchExpenses />
 			</MockedProvider>
 		)
 
-		fireEvent.click(await screen.findByText('search'))
+		await user.click(await screen.findByText('search'))
 
 		expect(await screen.findByText('results')).toBeVisible()
 	})
 
 	it('should re-issue the search with the same filters and the new page when the page changes', async () => {
+		const user = userEvent.setup()
+
 		render(
 			<MockedProvider mocks={[categoriesMock, searchExpensesPage1Mock, searchExpensesPage2Mock]} addTypename={false}>
 				<GetSearchExpenses />
 			</MockedProvider>
 		)
 
-		fireEvent.click(await screen.findByText('search'))
+		await user.click(await screen.findByText('search'))
 		await screen.findByText('results')
 
-		fireEvent.click(screen.getByText('next page'))
+		await user.click(screen.getByText('next page'))
 
 		expect(await screen.findByText('results')).toBeVisible()
 	})

--- a/src/components/Expenses/SearchExpensesFilters/index.test.js
+++ b/src/components/Expenses/SearchExpensesFilters/index.test.js
@@ -37,15 +37,15 @@ describe('SearchExpensesFilters', () => {
 
 		render(<SearchExpensesFilters categories={[...categories, categoryWithoutSubcategories]} onSearch={vi.fn()} />)
 
-		expect(screen.getByRole('option', { name: 'Select a category first' })).toBeInTheDocument()
+		expect(screen.getByRole('option', { name: 'Select a category first' })).toBeVisible()
 
 		await user.selectOptions(screen.getByLabelText('Category'), 'category-id-3')
 
-		expect(screen.getByRole('option', { name: 'No subcategories' })).toBeInTheDocument()
+		expect(screen.getByRole('option', { name: 'No subcategories' })).toBeVisible()
 
 		await user.selectOptions(screen.getByLabelText('Category'), 'category-id-1')
 
-		expect(screen.getByRole('option', { name: 'All subcategories' })).toBeInTheDocument()
+		expect(screen.getByRole('option', { name: 'All subcategories' })).toBeVisible()
 	})
 
 	it('should keep the subcategory selector disabled for a category that has no subcategories', async () => {
@@ -67,8 +67,8 @@ describe('SearchExpensesFilters', () => {
 		await user.selectOptions(screen.getByLabelText('Category'), 'category-id-1')
 
 		expect(screen.getByLabelText('Subcategory')).not.toBeDisabled()
-		expect(screen.getByRole('option', { name: 'Fuel' })).toBeInTheDocument()
-		expect(screen.getByRole('option', { name: 'Garage' })).toBeInTheDocument()
+		expect(screen.getByRole('option', { name: 'Fuel' })).toBeVisible()
+		expect(screen.getByRole('option', { name: 'Garage' })).toBeVisible()
 		expect(screen.queryByRole('option', { name: 'Electricity bill' })).not.toBeInTheDocument()
 	})
 

--- a/src/components/LoginForm/index.test.js
+++ b/src/components/LoginForm/index.test.js
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom/extend-expect'
 import { MockedProvider } from '@apollo/client/testing'
 import { InMemoryCache } from '@apollo/client'
@@ -9,7 +10,8 @@ import { LoginForm } from './'
 const customCache = new InMemoryCache()
 
 describe('LoginForm', () => {
-	it('should render a disabled button until password and email inputs are filled with data', () => {
+	it('should render a disabled button until password and email inputs are filled with data', async () => {
+		const user = userEvent.setup()
 		const activateAuth = vi.fn()
 		const mocks = []
 
@@ -26,18 +28,19 @@ describe('LoginForm', () => {
 		expect(passwordInput.value).toBe('')
 		expect(submitButton).toBeDisabled()
 
-		fireEvent.change(emailInput, { target: { value: 'example@mail.com' } })
+		await user.type(emailInput, 'example@mail.com')
 		expect(submitButton).toBeDisabled()
 
-		fireEvent.change(passwordInput, { target: { value: 'ABCabc*1234*4321' } })
+		await user.type(passwordInput, 'ABCabc*1234*4321')
 		expect(submitButton).not.toBeDisabled()
 
-		fireEvent.change(emailInput, { target: { value: '' } })
-		fireEvent.change(passwordInput, { target: { value: '' } })
+		await user.clear(emailInput)
+		await user.clear(passwordInput)
 		expect(submitButton).toBeDisabled()
 	})
 
 	it('should call to activateAuth method passing a token as argument if credentials are valid', async () => {
+		const user = userEvent.setup()
 		const activateAuth = vi.fn()
 		const mocks = [
 			{
@@ -68,9 +71,9 @@ describe('LoginForm', () => {
 		const passwordInput = screen.getByPlaceholderText(/password/)
 		const submitButton = screen.getByRole('button', { name: 'Log in' })
 
-		fireEvent.change(emailInput, { target: { value: 'example@mail.com' } })
-		fireEvent.change(passwordInput, { target: { value: 'ABCabc*1234*4321' } })
-		fireEvent.click(submitButton)
+		await user.type(emailInput, 'example@mail.com')
+		await user.type(passwordInput, 'ABCabc*1234*4321')
+		await user.click(submitButton)
 
 		const submitButtonLoadingState = screen.getByRole('button', { name: 'Loading' })
 
@@ -82,6 +85,7 @@ describe('LoginForm', () => {
 	})
 
 	it('should render an error if credentials are not valid', async () => {
+		const user = userEvent.setup()
 		const activateAuth = vi.fn()
 		const mocks = [
 			{
@@ -108,18 +112,18 @@ describe('LoginForm', () => {
 		const passwordInput = screen.getByPlaceholderText(/password/)
 		const submitButton = screen.getByRole('button', { name: 'Log in' })
 
-		fireEvent.change(emailInput, { target: { value: 'example@mail.com' } })
-		fireEvent.change(passwordInput, { target: { value: 'ABCabc*1234*4321' } })
-		fireEvent.click(submitButton)
+		await user.type(emailInput, 'example@mail.com')
+		await user.type(passwordInput, 'ABCabc*1234*4321')
+		await user.click(submitButton)
 
 		await waitFor(() => expect(activateAuth).not.toHaveBeenCalled())
 
 		const submitButtonAfterCTA = await screen.findByRole('button', { name: 'Log in' })
 
-		expect(submitButtonAfterCTA).toBeInTheDocument()
+		expect(submitButtonAfterCTA).toBeVisible()
 		expect(submitButtonAfterCTA).not.toBeDisabled()
 
-		expect(screen.getByRole('alert')).toBeInTheDocument()
+		expect(screen.getByRole('alert')).toBeVisible()
 		expect(screen.getByText('Invalid credentials'))
 	})
 })

--- a/src/components/SubmitButton/index.test.js
+++ b/src/components/SubmitButton/index.test.js
@@ -1,4 +1,5 @@
-import { render, fireEvent } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom/extend-expect'
 
 import { SubmitButton } from './'
@@ -22,7 +23,8 @@ describe('SubmitButton', () => {
 		expect(getByRole('button', { name: /^Submit$/i })).not.toBeDisabled()
 	})
 
-	it('captures clicks', () => {
+	it('captures clicks', async () => {
+		const user = userEvent.setup()
 		const handleClick = vi.fn()
 
 		const { getByRole } = render(
@@ -32,7 +34,7 @@ describe('SubmitButton', () => {
 		const node = getByRole('button', { name: /^Submit$/i })
 
 		expect(handleClick).not.toHaveBeenCalled()
-		fireEvent.click(node)
+		await user.click(node)
 		expect(handleClick).toHaveBeenCalled()
 	})
 })


### PR DESCRIPTION
### Cambios

- **fireEvent → userEvent** en `LoginForm`, `SubmitButton` y `GetSearchExpenses`: se reemplaza `fireEvent.change`/click por `user.type`/click/clear, se añade `userEvent.setup()` y se hacen async los tests necesarios.
- **toBeInTheDocument → toBeVisible** en elementos visibles: botón de login y alert en `LoginForm`, options de select en `SearchExpensesFilters`, SVGs en `DidibudgetLogo`.
- Los usos de `not.toBeInTheDocument()` se mantienen (verifican ausencia, uso correcto).

Basado en la skill `react-testing-library` del proyecto (reglas `user-prefer-userevent` y `assert-visible-over-in-document`).

212 tests passing, lint clean.