### PR TITLE
fix: remove deprecated addTypename prop and clean up test warnings

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -7,7 +7,7 @@ import { InMemoryCache } from '@apollo/client'
 import { App } from './App'
 import { AuthContext } from './AuthContext'
 
-const renderAppAt = (path, authValue = { isAuth: false, userData: {} }) => {
+const renderAppAt = (path, authValue = { isAuth: false, userData: {}, activateAuth: vi.fn(), removeAuth: vi.fn() }) => {
 	return render(
 		<MockedProvider mocks={[]} cache={new InMemoryCache()}>
 			<AuthContext.Provider value={authValue}>

--- a/src/components/Expenses/AddExpenseForm/index.test.js
+++ b/src/components/Expenses/AddExpenseForm/index.test.js
@@ -42,7 +42,7 @@ const successfulMutation = {
 	result: {
 		data: {
 			registerExpense: {
-				quantity: 12.4,
+				__typename: 'Expense', quantity: 12.4,
 				date: String(startOfToday().getTime()),
 				currencyISO: 'EUR',
 				uuid: 'expense-uuid-1'
@@ -59,7 +59,7 @@ const failingMutation = {
 
 const renderForm = (mocks = [successfulMutation]) => {
 	render(
-		<MockedProvider mocks={mocks} addTypename={false}>
+		<MockedProvider mocks={mocks} >
 			<AddExpenseForm categories={categories} frequentCategories={frequentCategories} />
 		</MockedProvider>
 	)

--- a/src/components/Expenses/GetAddExpenseData.test.js
+++ b/src/components/Expenses/GetAddExpenseData.test.js
@@ -20,7 +20,7 @@ const categoriesMock = {
 	result: {
 		data: {
 			getExpenseCategory: [
-				{ _id: 'category-id-2', name: 'Taxes', emojis: ['🏛'], uuid: 'category-uuid-2', subcategories: [] }
+				{ __typename: 'ExpenseCategory', _id: 'category-id-2', name: 'Taxes', emojis: ['🏛'], uuid: 'category-uuid-2', subcategories: [] }
 			]
 		}
 	}
@@ -32,7 +32,7 @@ const frequentMock = {
 		data: {
 			getMostUsedExpenseCategories: [
 				{
-					category: 'category-id-2',
+					__typename: 'MostUsedExpenseCategory', category: 'category-id-2',
 					categoryName: 'Taxes',
 					categoryEmojis: ['🏛'],
 					subcategory: null,
@@ -57,7 +57,7 @@ const failingCategoriesMock = {
 describe('GetAddExpenseData', () => {
 	it('passes the frequent categories to the form', async () => {
 		render(
-			<MockedProvider mocks={[categoriesMock, frequentMock]} addTypename={false}>
+			<MockedProvider mocks={[categoriesMock, frequentMock]} >
 				<GetAddExpenseData />
 			</MockedProvider>
 		)
@@ -69,7 +69,7 @@ describe('GetAddExpenseData', () => {
 		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
 
 		render(
-			<MockedProvider mocks={[categoriesMock, failingFrequentMock]} addTypename={false}>
+			<MockedProvider mocks={[categoriesMock, failingFrequentMock]} >
 				<GetAddExpenseData />
 			</MockedProvider>
 		)
@@ -82,7 +82,7 @@ describe('GetAddExpenseData', () => {
 
 	it('shows an error when the categories fail', async () => {
 		render(
-			<MockedProvider mocks={[failingCategoriesMock, frequentMock]} addTypename={false}>
+			<MockedProvider mocks={[failingCategoriesMock, frequentMock]} >
 				<GetAddExpenseData />
 			</MockedProvider>
 		)

--- a/src/components/Expenses/GetSearchExpenses.test.js
+++ b/src/components/Expenses/GetSearchExpenses.test.js
@@ -47,12 +47,12 @@ const categoriesMock = {
 		data: {
 			getExpenseCategory: [
 				{
-					_id: 'category-id-1',
+					__typename: 'ExpenseCategory', _id: 'category-id-1',
 					name: 'Private vehicles',
 					emojis: ['🚙'],
 					uuid: 'category-uuid-1',
 					subcategories: [
-						{ _id: 'subcategory-id-1', name: 'Fuel', uuid: 'subcategory-uuid-1', emojis: ['⛽️'] }
+						{ __typename: 'ExpenseSubcategory', _id: 'subcategory-id-1', name: 'Fuel', uuid: 'subcategory-uuid-1', emojis: ['⛽️'] }
 					]
 				}
 			]
@@ -61,8 +61,8 @@ const categoriesMock = {
 }
 
 const searchResultMock = {
-	expenses: [],
-	pagination: { currentPage: 1, totalPages: 1, totalCount: 0 },
+	__typename: 'ExpenseSearchResult', expenses: [],
+	pagination: { __typename: 'PaginationData', currentPage: 1, totalPages: 1, totalCount: 0 },
 	totalSum: 0,
 	currencyISO: 'EUR',
 	breakdown: []
@@ -81,7 +81,7 @@ const searchExpensesPage2Mock = {
 describe('GetSearchExpenses', () => {
 	it('should display a spinner while the categories are loading', () => {
 		render(
-			<MockedProvider mocks={[categoriesMock]} addTypename={false}>
+			<MockedProvider mocks={[categoriesMock]} >
 				<GetSearchExpenses />
 			</MockedProvider>
 		)
@@ -91,7 +91,7 @@ describe('GetSearchExpenses', () => {
 
 	it('should display the filters form once the categories are loaded', async () => {
 		render(
-			<MockedProvider mocks={[categoriesMock]} addTypename={false}>
+			<MockedProvider mocks={[categoriesMock]} >
 				<GetSearchExpenses />
 			</MockedProvider>
 		)
@@ -101,7 +101,7 @@ describe('GetSearchExpenses', () => {
 
 	it('should not display any result before the first search', async () => {
 		render(
-			<MockedProvider mocks={[categoriesMock]} addTypename={false}>
+			<MockedProvider mocks={[categoriesMock]} >
 				<GetSearchExpenses />
 			</MockedProvider>
 		)
@@ -118,7 +118,7 @@ describe('GetSearchExpenses', () => {
 		}
 
 		render(
-			<MockedProvider mocks={[errorMock]} addTypename={false}>
+			<MockedProvider mocks={[errorMock]} >
 				<GetSearchExpenses />
 			</MockedProvider>
 		)
@@ -130,7 +130,7 @@ describe('GetSearchExpenses', () => {
 		const user = userEvent.setup()
 
 		render(
-			<MockedProvider mocks={[categoriesMock, searchExpensesPage1Mock]} addTypename={false}>
+			<MockedProvider mocks={[categoriesMock, searchExpensesPage1Mock]} >
 				<GetSearchExpenses />
 			</MockedProvider>
 		)
@@ -144,7 +144,7 @@ describe('GetSearchExpenses', () => {
 		const user = userEvent.setup()
 
 		render(
-			<MockedProvider mocks={[categoriesMock, searchExpensesPage1Mock, searchExpensesPage2Mock]} addTypename={false}>
+			<MockedProvider mocks={[categoriesMock, searchExpensesPage1Mock, searchExpensesPage2Mock]} >
 				<GetSearchExpenses />
 			</MockedProvider>
 		)

--- a/src/components/LazyRoute/index.test.js
+++ b/src/components/LazyRoute/index.test.js
@@ -3,13 +3,20 @@ import { render, screen } from '@testing-library/react'
 
 import { LazyRoute } from './index'
 
-const createLazyScreen = () => lazy(() => Promise.resolve({
-	default: () => <p>Loaded screen</p>
-}))
+const createLazyScreen = () => {
+	const deferred = {}
+	const promise = new Promise((resolve) => {
+		deferred.resolve = () => resolve({
+			default: () => <p>Loaded screen</p>
+		})
+	})
+	const LazyScreen = lazy(() => promise)
+	return { LazyScreen, load: deferred.resolve }
+}
 
 describe('LazyRoute', () => {
 	it('shows the spinner while the screen is still loading', () => {
-		const LazyScreen = createLazyScreen()
+		const { LazyScreen } = createLazyScreen()
 
 		render(<LazyRoute><LazyScreen /></LazyRoute>)
 
@@ -17,17 +24,19 @@ describe('LazyRoute', () => {
 	})
 
 	it('shows the screen once it has loaded', async () => {
-		const LazyScreen = createLazyScreen()
+		const { LazyScreen, load } = createLazyScreen()
 
 		render(<LazyRoute><LazyScreen /></LazyRoute>)
+		load()
 
 		expect(await screen.findByText('Loaded screen')).toBeVisible()
 	})
 
 	it('does not show the spinner once the screen has loaded', async () => {
-		const LazyScreen = createLazyScreen()
+		const { LazyScreen, load } = createLazyScreen()
 
 		render(<LazyRoute><LazyScreen /></LazyRoute>)
+		load()
 		await screen.findByText('Loaded screen')
 
 		expect(screen.queryByText('Loading...')).not.toBeInTheDocument()


### PR DESCRIPTION
## Summary

Cleans up warnings and stderr noise from the test suite without changing any test behavior.

### Changes

1. **Apollo `addTypename` (3 files)**
   - Removed deprecated `addTypename={false}` prop from `MockedProvider` (removed in Apollo 3.14+)
   - Added proper `__typename` to all mock objects using types from the backend GraphQL schema

2. **AuthContext mock in App.test.js**
   - Added `activateAuth` and `removeAuth` mock functions to the test's context provider value to match the real provider shape

3. **LazyRoute test**
   - Replaced immediately-resolving promise with a deferred promise to prevent `act()` warning from premature lazy component resolution

### Verification
- ✅ 38 test files, 284 tests — all passing
- ✅ ESLint clean