### PR TITLE
feat: responsive user administration with search and badges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,10 @@ npm run lint -- src/pages/Login.js  # Lint specific file
 - `src/AuthContext.js` - Global auth state; affects routing and protected components
 
 
+## UI Patterns
+
+Before creating any new UI element, find an existing similar element in the codebase and match its styling approach — same Bootstrap classes, same custom CSS patterns, same markup structure. Don't invent new custom styles when the project already has a convention.
+
 ## Accessibility & Dark Theme Colors
 
 This app uses a dark theme (`bg-dark`, `#212529`). Text on dark backgrounds must meet WCAG AA contrast (≥4.5:1). Conventions for text utility classes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ Mutations typically use `useMutation` hook with error/success handling.
 - Test files colocated with components/modules (`.test.js` suffix)
 - Uses React Testing Library (component testing, NOT enzyme)
 - Tests typically verify rendering and user interactions
+- There is a [react-testing-library skill](.agents/skills/react-testing-library/SKILL.md) with 43 rules (query selection, async handling, anti-patterns, etc.). Reference it when writing or reviewing tests.
 
 Run tests:
 ```bash

--- a/src/components/Users/ListOfUsers/index.js
+++ b/src/components/Users/ListOfUsers/index.js
@@ -34,8 +34,8 @@ export const ListOfUsers = ({ users, startPolling, stopPolling }) => {
 	return (
 		<section>
 			<input
-				type="text"
-				className="search-input"
+				type="search"
+				className="form-control mb-3"
 				placeholder="Search by email..."
 				aria-label="Search by email"
 				value={search}

--- a/src/components/Users/ListOfUsers/index.js
+++ b/src/components/Users/ListOfUsers/index.js
@@ -4,81 +4,82 @@ import PropTypes from 'prop-types'
 import { parseUnixTimestamp, getTimeAgo } from '../../../utils/utils'
 import './styles.css'
 
+const roleBadge = (isAdmin) => {
+	if (isAdmin) { return <span className="badge-admin">Admin</span> }
+	return <span className="badge-user">User</span>
+}
+
+const statusBadge = (isActive) => {
+	if (isActive) { return <span className="badge-active">Active</span> }
+	return <span className="badge-inactive">Inactive</span>
+}
+
 export const ListOfUsers = ({ users, startPolling, stopPolling }) => {
-  const [search, setSearch] = useState('')
+	const [search, setSearch] = useState('')
 
-  useEffect(() => {
-    const minuteInMilliseconds = 60000
-    const tenMinutes = minuteInMilliseconds * 10
-    startPolling(tenMinutes)
+	useEffect(() => {
+		const minuteInMilliseconds = 60000
+		const tenMinutes = minuteInMilliseconds * 10
+		startPolling(tenMinutes)
 
-    return () => {
-      stopPolling()
-    }
-  }, [startPolling, stopPolling])
+		return () => {
+			stopPolling()
+		}
+	}, [startPolling, stopPolling])
 
-  const filteredUsers = users.filter(user =>
-    user.email.toLowerCase().includes(search.toLowerCase())
-  )
+	const filteredUsers = users.filter(user =>
+		user.email.toLowerCase().includes(search.toLowerCase())
+	)
 
-  const roleBadge = (isAdmin) => {
-    if (isAdmin) { return <span className="badge-admin">Admin</span> }
-    return <span className="badge-user">User</span>
-  }
-
-  const statusBadge = (isActive) => {
-    if (isActive) { return <span className="badge-active">Active</span> }
-    return <span className="badge-inactive">Inactive</span>
-  }
-
-  return (
-    <section>
-      <input
-        type="text"
-        className="search-input"
-        placeholder="Search by email..."
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-      />
-      <div className="table-responsive">
-        <table className="table text-light responsive-table">
-          <thead>
-            <tr>
-              <th scope="col">Email</th>
-              <th scope="col">Role</th>
-              <th scope="col">Status</th>
-              <th scope="col">Registered</th>
-              <th scope="col">Last login</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filteredUsers.map(user => (
-              <tr key={user.uuid}>
-                <td data-label="Email">{user.email}</td>
-                <td data-label="Role">{roleBadge(user.isAdmin)}</td>
-                <td data-label="Status">{statusBadge(user.isActive)}</td>
-                <td data-label="Registered">{getTimeAgo(user.registrationDate)}</td>
-                <td data-label="Last login">{parseUnixTimestamp(user.lastLogin)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </section>
-  )
+	return (
+		<section>
+			<input
+				type="text"
+				className="search-input"
+				placeholder="Search by email..."
+				aria-label="Search by email"
+				value={search}
+				onChange={(e) => setSearch(e.target.value)}
+			/>
+			<div className="table-responsive">
+				<table className="table text-light responsive-table">
+					<thead>
+						<tr>
+							<th scope="col">Email</th>
+							<th scope="col">Role</th>
+							<th scope="col">Status</th>
+							<th scope="col">Registered</th>
+							<th scope="col">Last login</th>
+						</tr>
+					</thead>
+					<tbody>
+						{filteredUsers.map(user => (
+							<tr key={user.uuid}>
+								<td data-label="Email">{user.email}</td>
+								<td data-label="Role">{roleBadge(user.isAdmin)}</td>
+								<td data-label="Status">{statusBadge(user.isActive)}</td>
+								<td data-label="Registered">{getTimeAgo(user.registrationDate)}</td>
+								<td data-label="Last login">{parseUnixTimestamp(user.lastLogin)}</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
+		</section>
+	)
 }
 
 ListOfUsers.propTypes = {
-  users: PropTypes.arrayOf(
-    PropTypes.shape({
-      email: PropTypes.string.isRequired,
-      uuid: PropTypes.string.isRequired,
-      isAdmin: PropTypes.bool.isRequired,
-      isActive: PropTypes.bool.isRequired,
-      registrationDate: PropTypes.string.isRequired,
-      lastLogin: PropTypes.string.isRequired
-    })
-  ),
-  startPolling: PropTypes.func.isRequired,
-  stopPolling: PropTypes.func.isRequired
+	users: PropTypes.arrayOf(
+		PropTypes.shape({
+			email: PropTypes.string.isRequired,
+			uuid: PropTypes.string.isRequired,
+			isAdmin: PropTypes.bool.isRequired,
+			isActive: PropTypes.bool.isRequired,
+			registrationDate: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+			lastLogin: PropTypes.string.isRequired
+		})
+	),
+	startPolling: PropTypes.func.isRequired,
+	stopPolling: PropTypes.func.isRequired
 }

--- a/src/components/Users/ListOfUsers/index.js
+++ b/src/components/Users/ListOfUsers/index.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 
-import { parseUnixTimestamp, getTimeAgo } from '../../../utils/utils'
+import { getTimeAgo } from '../../../utils/utils'
 import './styles.css'
 
 const roleBadge = (isAdmin) => {
@@ -59,7 +59,7 @@ export const ListOfUsers = ({ users, startPolling, stopPolling }) => {
 								<td data-label="Role">{roleBadge(user.isAdmin)}</td>
 								<td data-label="Status">{statusBadge(user.isActive)}</td>
 								<td data-label="Registered">{getTimeAgo(user.registrationDate)}</td>
-								<td data-label="Last login">{parseUnixTimestamp(user.lastLogin)}</td>
+								<td data-label="Last login">{getTimeAgo(user.lastLogin)}</td>
 							</tr>
 						))}
 					</tbody>

--- a/src/components/Users/ListOfUsers/index.js
+++ b/src/components/Users/ListOfUsers/index.js
@@ -1,66 +1,84 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 
 import { parseUnixTimestamp, getTimeAgo } from '../../../utils/utils'
-import { EmojiGreenCheck } from '../../EmojiGreenCheck'
-import { EmojiRedCross } from '../../EmojiRedCross'
+import './styles.css'
 
 export const ListOfUsers = ({ users, startPolling, stopPolling }) => {
+  const [search, setSearch] = useState('')
 
-	useEffect(() => {
-		const minuteInMilliseconds = 60000
-		const tenMinutes = minuteInMilliseconds * 10
-		startPolling(tenMinutes)
+  useEffect(() => {
+    const minuteInMilliseconds = 60000
+    const tenMinutes = minuteInMilliseconds * 10
+    startPolling(tenMinutes)
 
-		return () => {
-			stopPolling()
-		}
-	}, [startPolling, stopPolling])
+    return () => {
+      stopPolling()
+    }
+  }, [startPolling, stopPolling])
 
-	return (
-		<section className="table-responsive">
-			<table className="table text-light">
-				<thead>
-					<tr>
-						<th scope="col">Email</th>
-						<th scope="col">Is administrator?</th>
-						<th scope="col">Is active?</th>
-						<th scope="col">Registration date</th>
-						<th scope="col">Last login</th>
-					</tr>
-				</thead>
-				<tbody>
-					{
-						users.map(user => {
-							return (
-								<tr key={user.uuid}>
-									<td>{user.email}</td>
-									<td>{(user.isAdmin) ? <EmojiGreenCheck /> : <EmojiRedCross />}</td>
-									<td>{(user.isActive) ? <EmojiGreenCheck /> : <EmojiRedCross />}</td>
-									<td>{getTimeAgo(user.registrationDate)}</td>
-									<td>{parseUnixTimestamp(user.lastLogin)}</td>
-								</tr>
-							)
-						})
-					}
-				</tbody>
-			</table>
-		</section>
-	)
+  const filteredUsers = users.filter(user =>
+    user.email.toLowerCase().includes(search.toLowerCase())
+  )
+
+  const roleBadge = (isAdmin) => {
+    if (isAdmin) { return <span className="badge-admin">Admin</span> }
+    return <span className="badge-user">User</span>
+  }
+
+  const statusBadge = (isActive) => {
+    if (isActive) { return <span className="badge-active">Active</span> }
+    return <span className="badge-inactive">Inactive</span>
+  }
+
+  return (
+    <section>
+      <input
+        type="text"
+        className="search-input"
+        placeholder="Search by email..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+      <div className="table-responsive">
+        <table className="table text-light responsive-table">
+          <thead>
+            <tr>
+              <th scope="col">Email</th>
+              <th scope="col">Role</th>
+              <th scope="col">Status</th>
+              <th scope="col">Registered</th>
+              <th scope="col">Last login</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredUsers.map(user => (
+              <tr key={user.uuid}>
+                <td data-label="Email">{user.email}</td>
+                <td data-label="Role">{roleBadge(user.isAdmin)}</td>
+                <td data-label="Status">{statusBadge(user.isActive)}</td>
+                <td data-label="Registered">{getTimeAgo(user.registrationDate)}</td>
+                <td data-label="Last login">{parseUnixTimestamp(user.lastLogin)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
 }
 
-
 ListOfUsers.propTypes = {
-	users: PropTypes.arrayOf(
-		PropTypes.shape({
-			email: PropTypes.string.isRequired,
-			uuid: PropTypes.string.isRequired,
-			isAdmin: PropTypes.bool.isRequired,
-			isActive: PropTypes.bool.isRequired,
-			registrationDate: PropTypes.string.isRequired,
-			lastLogin: PropTypes.string.isRequired
-		})
-	),
-	startPolling: PropTypes.func.isRequired,
-	stopPolling: PropTypes.func.isRequired
+  users: PropTypes.arrayOf(
+    PropTypes.shape({
+      email: PropTypes.string.isRequired,
+      uuid: PropTypes.string.isRequired,
+      isAdmin: PropTypes.bool.isRequired,
+      isActive: PropTypes.bool.isRequired,
+      registrationDate: PropTypes.string.isRequired,
+      lastLogin: PropTypes.string.isRequired
+    })
+  ),
+  startPolling: PropTypes.func.isRequired,
+  stopPolling: PropTypes.func.isRequired
 }

--- a/src/components/Users/ListOfUsers/index.js
+++ b/src/components/Users/ListOfUsers/index.js
@@ -55,11 +55,11 @@ export const ListOfUsers = ({ users, startPolling, stopPolling }) => {
 					<tbody>
 						{filteredUsers.map(user => (
 							<tr key={user.uuid}>
-								<td data-label="Email">{user.email}</td>
-								<td data-label="Role">{roleBadge(user.isAdmin)}</td>
-								<td data-label="Status">{statusBadge(user.isActive)}</td>
-								<td data-label="Registered">{getTimeAgo(user.registrationDate)}</td>
-								<td data-label="Last login">{getTimeAgo(user.lastLogin)}</td>
+								<td data-label="Email"><span className="value">{user.email}</span></td>
+								<td data-label="Role"><span className="value">{roleBadge(user.isAdmin)}</span></td>
+								<td data-label="Status"><span className="value">{statusBadge(user.isActive)}</span></td>
+								<td data-label="Registered"><span className="value">{getTimeAgo(user.registrationDate)}</span></td>
+								<td data-label="Last login"><span className="value">{getTimeAgo(user.lastLogin)}</span></td>
 							</tr>
 						))}
 					</tbody>

--- a/src/components/Users/ListOfUsers/index.test.js
+++ b/src/components/Users/ListOfUsers/index.test.js
@@ -110,9 +110,9 @@ describe('ListOfUsers', () => {
     expect(screen.queryByText('alice@example.com')).not.toBeInTheDocument()
   })
 
-  it('renders registration date', () => {
+  it('renders relative time for registration and last login', () => {
     renderList()
-    expect(screen.getAllByText(/ago/)).toHaveLength(3)
+    expect(screen.getAllByText(/ago/)).toHaveLength(6)
   })
 
   it('renders empty state when no users provided', () => {

--- a/src/components/Users/ListOfUsers/index.test.js
+++ b/src/components/Users/ListOfUsers/index.test.js
@@ -1,0 +1,134 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ListOfUsers } from './'
+
+const mockUsers = [
+  {
+    uuid: '1',
+    email: 'alice@example.com',
+    isAdmin: true,
+    isActive: true,
+    registrationDate: 1715776800000,
+    lastLogin: '1700000000'
+  },
+  {
+    uuid: '2',
+    email: 'bob@example.com',
+    isAdmin: false,
+    isActive: true,
+    registrationDate: 1704976800000,
+    lastLogin: '1735689600'
+  },
+  {
+    uuid: '3',
+    email: 'carol@example.com',
+    isAdmin: true,
+    isActive: false,
+    registrationDate: 1718877600000,
+    lastLogin: '1700100000'
+  }
+]
+
+const mockStartPolling = vi.fn()
+const mockStopPolling = vi.fn()
+
+const renderList = (users = mockUsers) => {
+  return render(
+    <ListOfUsers
+      users={users}
+      startPolling={mockStartPolling}
+      stopPolling={mockStopPolling}
+    />
+  )
+}
+
+describe('ListOfUsers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders table headers', () => {
+    renderList()
+    expect(screen.getByText('Email')).toBeInTheDocument()
+    expect(screen.getByText('Role')).toBeInTheDocument()
+    expect(screen.getByText('Status')).toBeInTheDocument()
+    expect(screen.getByText('Registered')).toBeInTheDocument()
+    expect(screen.getByText('Last login')).toBeInTheDocument()
+  })
+
+  it('renders all users', () => {
+    renderList()
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument()
+    expect(screen.getByText('bob@example.com')).toBeInTheDocument()
+    expect(screen.getByText('carol@example.com')).toBeInTheDocument()
+  })
+
+  it('shows Admin badge for admin users', () => {
+    renderList()
+    expect(screen.getAllByText('Admin')).toHaveLength(2)
+  })
+
+  it('shows User badge for non-admin users', () => {
+    renderList()
+    expect(screen.getByText('User')).toBeInTheDocument()
+  })
+
+  it('shows Active badge for active users', () => {
+    renderList()
+    expect(screen.getAllByText('Active')).toHaveLength(2)
+  })
+
+  it('shows Inactive badge for inactive users', () => {
+    renderList()
+    expect(screen.getByText('Inactive')).toBeInTheDocument()
+  })
+
+  it('filters users by email search', async () => {
+    const user = userEvent.setup()
+    renderList()
+    const input = screen.getByPlaceholderText('Search by email...')
+    await user.type(input, 'alice')
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument()
+    expect(screen.queryByText('bob@example.com')).not.toBeInTheDocument()
+    expect(screen.queryByText('carol@example.com')).not.toBeInTheDocument()
+  })
+
+  it('filters users case-insensitively', async () => {
+    const user = userEvent.setup()
+    renderList()
+    const input = screen.getByPlaceholderText('Search by email...')
+    await user.type(input, 'BOB')
+    expect(screen.getByText('bob@example.com')).toBeInTheDocument()
+    expect(screen.queryByText('alice@example.com')).not.toBeInTheDocument()
+  })
+
+  it('shows no users when search matches nothing', async () => {
+    const user = userEvent.setup()
+    renderList()
+    const input = screen.getByPlaceholderText('Search by email...')
+    await user.type(input, 'zzzzz')
+    expect(screen.queryByText('alice@example.com')).not.toBeInTheDocument()
+  })
+
+  it('renders registration date', () => {
+    renderList()
+    expect(screen.getAllByText(/ago/)).toHaveLength(3)
+  })
+
+  it('renders empty state when no users provided', () => {
+    renderList([])
+    expect(screen.getByText('Email')).toBeInTheDocument()
+  })
+
+  it('starts polling on mount', () => {
+    renderList()
+    expect(mockStartPolling).toHaveBeenCalledTimes(1)
+    expect(mockStartPolling).toHaveBeenCalledWith(600000)
+  })
+
+  it('stops polling on unmount', () => {
+    const { unmount } = renderList()
+    unmount()
+    expect(mockStopPolling).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/Users/ListOfUsers/styles.css
+++ b/src/components/Users/ListOfUsers/styles.css
@@ -42,6 +42,13 @@
   white-space: nowrap;
 }
 
+.responsive-table td[data-label="Email"] {
+  max-width: 250px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .search-input {
   background: #3d3d3f;
   border: 1px solid #424245;

--- a/src/components/Users/ListOfUsers/styles.css
+++ b/src/components/Users/ListOfUsers/styles.css
@@ -1,0 +1,97 @@
+@media (max-width: 767.98px) {
+  .responsive-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .responsive-table tr {
+    display: block;
+    margin-bottom: 0.75rem;
+    border: 1px solid #424245;
+    border-radius: 8px;
+    background: #2d2d2f;
+  }
+
+  .responsive-table td {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem 0.75rem;
+    border: none;
+  }
+
+  .responsive-table td::before {
+    content: attr(data-label);
+    color: #86868b;
+    font-size: 0.75rem;
+    flex-shrink: 0;
+    margin-right: 1rem;
+  }
+
+  .responsive-table td:last-child {
+    border-bottom: none;
+  }
+}
+
+.responsive-table th {
+  white-space: nowrap;
+}
+
+.search-input {
+  background: #3d3d3f;
+  border: 1px solid #424245;
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  color: #f5f5f7;
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.search-input::placeholder {
+  color: #636366;
+}
+
+.badge-admin {
+  display: inline-block;
+  background: rgba(10, 132, 255, 0.15);
+  color: #0a84ff;
+  font-size: 0.75rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.badge-active {
+  display: inline-block;
+  background: rgba(52, 199, 89, 0.15);
+  color: #34c759;
+  font-size: 0.75rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.badge-inactive {
+  display: inline-block;
+  background: rgba(255, 59, 48, 0.15);
+  color: #ff3b30;
+  font-size: 0.75rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.badge-user {
+  display: inline-block;
+  background: rgba(134, 134, 139, 0.15);
+  color: #86868b;
+  font-size: 0.75rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 4px;
+  font-weight: 500;
+}

--- a/src/components/Users/ListOfUsers/styles.css
+++ b/src/components/Users/ListOfUsers/styles.css
@@ -36,6 +36,10 @@
   .responsive-table td:last-child {
     border-bottom: none;
   }
+
+  .responsive-table td .value {
+    text-align: right;
+  }
 }
 
 .responsive-table th {

--- a/src/components/Users/ListOfUsers/styles.css
+++ b/src/components/Users/ListOfUsers/styles.css
@@ -38,8 +38,17 @@
   }
 
   .responsive-table td .value {
+    flex: 1;
     text-align: right;
+    min-width: 0;
   }
+
+  .responsive-table td[data-label="Email"] {
+    max-width: none;
+    overflow: visible;
+    white-space: normal;
+  }
+
 }
 
 .responsive-table th {

--- a/src/components/Users/ListOfUsers/styles.css
+++ b/src/components/Users/ListOfUsers/styles.css
@@ -27,7 +27,7 @@
 
   .responsive-table td::before {
     content: attr(data-label);
-    color: #86868b;
+    color: #a1a1a6;
     font-size: 0.75rem;
     flex-shrink: 0;
     margin-right: 1rem;
@@ -47,20 +47,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.search-input {
-  background: #3d3d3f;
-  border: 1px solid #424245;
-  border-radius: 8px;
-  padding: 0.5rem 0.75rem;
-  color: #f5f5f7;
-  width: 100%;
-  margin-bottom: 1rem;
-}
-
-.search-input::placeholder {
-  color: #636366;
 }
 
 .badge-admin {
@@ -96,7 +82,7 @@
 .badge-user {
   display: inline-block;
   background: rgba(134, 134, 139, 0.15);
-  color: #86868b;
+  color: #a1a1a6;
   font-size: 0.75rem;
   padding: 0.1rem 0.5rem;
   border-radius: 4px;

--- a/src/components/Users/ListOfUsers/styles.css
+++ b/src/components/Users/ListOfUsers/styles.css
@@ -2,13 +2,6 @@
   white-space: nowrap;
 }
 
-.responsive-table td[data-label="Email"] {
-  max-width: 250px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 @media (max-width: 767.98px) {
   .responsive-table thead {
     position: absolute;
@@ -54,11 +47,6 @@
     min-width: 0;
   }
 
-  .responsive-table td[data-label="Email"] {
-    max-width: none;
-    overflow: visible;
-    white-space: normal;
-  }
 }
 
 .badge-admin {

--- a/src/components/Users/ListOfUsers/styles.css
+++ b/src/components/Users/ListOfUsers/styles.css
@@ -1,3 +1,14 @@
+.responsive-table th {
+  white-space: nowrap;
+}
+
+.responsive-table td[data-label="Email"] {
+  max-width: 250px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 @media (max-width: 767.98px) {
   .responsive-table thead {
     position: absolute;
@@ -48,18 +59,6 @@
     overflow: visible;
     white-space: normal;
   }
-
-}
-
-.responsive-table th {
-  white-space: nowrap;
-}
-
-.responsive-table td[data-label="Email"] {
-  max-width: 250px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .badge-admin {


### PR DESCRIPTION
## Summary

Rediseño responsive de la página de administración de usuarios.

## Changes

- **Responsive table → cards**: La tabla se convierte en tarjetas en móvil (<768px) vía CSS puro, sin duplicar markup ni usar JS
- **Search filter**: Filtro de búsqueda por email con  de Bootstrap (consistente con el resto de la app)
- **Badges**: Reemplazo de emojis ✅/❌ por badges de texto (Admin/User, Active/Inactive) con colores semánticos
- **Relative time**: Last login ahora muestra tiempo relativo como Registration date
- **AGENTS.md**: Nueva sección UI Patterns para mantener consistencia visual
- **Tests**: 13 tests para ListOfUsers cubriendo renderizado, badges, búsqueda, empty state y polling lifecycle

## Commits

10 commits que incluyen: CSS responsive, rewrite del componente, tests, correcciones de code review y ajustes de alineación en mobile.