### PR TITLE
fix: hide thead in mobile to prevent visual artifact

### DIFF
--- a/src/components/Users/ListOfUsers/styles.css
+++ b/src/components/Users/ListOfUsers/styles.css
@@ -4,13 +4,7 @@
 
 @media (max-width: 767.98px) {
   .responsive-table thead {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
+    display: none;
   }
 
   .responsive-table tr {


### PR DESCRIPTION
Switches thead hiding from absolute+clip to display:none on mobile. The previous technique left a visible line artifact above the first card.