### PR TITLE
fix: remove tbody border-top on mobile from ListOfUsers

### DIFF
--- a/src/components/Users/ListOfUsers/styles.css
+++ b/src/components/Users/ListOfUsers/styles.css
@@ -13,6 +13,10 @@
     border: 0;
   }
 
+  .responsive-table > :not(:first-child) {
+    border-top: 0;
+  }
+
   .responsive-table tr {
     display: block;
     margin-bottom: 0.75rem;


### PR DESCRIPTION
Bootstrap 5.1.3 adds a border-top to tbody via its table class. On mobile when the thead is hidden, this border shows as a light-colored line above the first card. The fix overrides it with matching specificity inside the media query.