### PR TITLE
fix: let password managers autofill the credential forms

### DIFF
--- a/src/components/LoginForm/index.js
+++ b/src/components/LoginForm/index.js
@@ -42,14 +42,14 @@ export const LoginForm = ({ activateAuth }) => {
 
 	return (
 		<Fragment>
-			<form className="row" disabled={isDisabled} onSubmit={handleSubmit}>
+			<form className="row" onSubmit={handleSubmit}>
 				<div className="col-md-6">
 					<label htmlFor="inputEmailLoginForm" className="form-label text-light">Email <span className="text-danger">*</span></label>
-					<input disabled={isDisabled} inputMode="email" className="form-control" id="inputEmailLoginForm" placeholder='email' {...email} required autoFocus />
+					<input disabled={isDisabled} type='email' name="email" autoComplete="username" className="form-control" id="inputEmailLoginForm" placeholder='email' {...email} required autoFocus />
 				</div>
 				<div className="col-md-6">
 					<label htmlFor="inputPasswordLoginForm" className="form-label text-light">Password <span className="text-danger">*</span></label>
-					<input disabled={isDisabled} className="form-control" id="inputPasswordLoginForm" placeholder='password' type='password' {...password} required />
+					<input disabled={isDisabled} type='password' name="password" autoComplete="current-password" className="form-control" id="inputPasswordLoginForm" placeholder='password' {...password} required />
 				</div>
 				<div className="my-4">
 					<SubmitButton disabled={isDisabled || !validateLoginForm(email.value, password.value)}>

--- a/src/components/LoginForm/index.test.js
+++ b/src/components/LoginForm/index.test.js
@@ -21,11 +21,11 @@ describe('LoginForm', () => {
 			</MockedProvider>
 		)
 		const emailInput = screen.getByRole('textbox', { name: /Email/i })
-		const passwordInput = screen.getByPlaceholderText(/password/)
+		const passwordInput = screen.getByLabelText(/Password/i)
 		const submitButton = screen.getByRole('button', { name: 'Log in' })
 
-		expect(emailInput.value).toBe('')
-		expect(passwordInput.value).toBe('')
+		expect(emailInput).toHaveValue('')
+		expect(passwordInput).toHaveValue('')
 		expect(submitButton).toBeDisabled()
 
 		await user.type(emailInput, 'example@mail.com')
@@ -37,6 +37,42 @@ describe('LoginForm', () => {
 		await user.clear(emailInput)
 		await user.clear(passwordInput)
 		expect(submitButton).toBeDisabled()
+	})
+
+	it('should expose the autofill hints that password managers rely on', () => {
+		const activateAuth = vi.fn()
+
+		render(
+			<MockedProvider mocks={[]} cache={customCache}>
+				<LoginForm activateAuth={activateAuth} />
+			</MockedProvider>
+		)
+
+		const emailInput = screen.getByRole('textbox', { name: /Email/i })
+		const passwordInput = screen.getByLabelText(/Password/i)
+
+		expect(emailInput).toHaveAttribute('type', 'email')
+		expect(emailInput).toHaveAttribute('autocomplete', 'username')
+		expect(passwordInput).toHaveAttribute('autocomplete', 'current-password')
+	})
+
+	it('should enable the button for a stored password that would not pass the registration rules', async () => {
+		const user = userEvent.setup()
+		const activateAuth = vi.fn()
+
+		render(
+			<MockedProvider mocks={[]} cache={customCache}>
+				<LoginForm activateAuth={activateAuth} />
+			</MockedProvider>
+		)
+
+		const emailInput = screen.getByRole('textbox', { name: /Email/i })
+		const passwordInput = screen.getByLabelText(/Password/i)
+
+		await user.type(emailInput, 'example@mail.com')
+		await user.type(passwordInput, 'w~mb(3Qz)tf')
+
+		expect(screen.getByRole('button', { name: 'Log in' })).not.toBeDisabled()
 	})
 
 	it('should call to activateAuth method passing a token as argument if credentials are valid', async () => {
@@ -68,7 +104,7 @@ describe('LoginForm', () => {
 		)
 
 		const emailInput = screen.getByRole('textbox', { name: /Email/i })
-		const passwordInput = screen.getByPlaceholderText(/password/)
+		const passwordInput = screen.getByLabelText(/Password/i)
 		const submitButton = screen.getByRole('button', { name: 'Log in' })
 
 		await user.type(emailInput, 'example@mail.com')
@@ -109,7 +145,7 @@ describe('LoginForm', () => {
 		)
 
 		const emailInput = screen.getByRole('textbox', { name: /Email/i })
-		const passwordInput = screen.getByPlaceholderText(/password/)
+		const passwordInput = screen.getByLabelText(/Password/i)
 		const submitButton = screen.getByRole('button', { name: 'Log in' })
 
 		await user.type(emailInput, 'example@mail.com')

--- a/src/components/RegisterForm/index.js
+++ b/src/components/RegisterForm/index.js
@@ -44,12 +44,14 @@ export const RegisterForm = ({ activateAuth }) => {
 	return (
 		<Fragment>
 			<div className="row justify-content-center mt-4">
-				<form className="col-md-8" disabled={isDisabled} onSubmit={handleSubmit}>
+				<form className="col-md-8" onSubmit={handleSubmit}>
 					<div className="col mb-3">
 						<label htmlFor="inputEmailRegisterForm" className="text-light">Email <span className="text-danger">*</span></label>
 						<input
 							disabled={isDisabled}
-							inputMode="email"
+							type='email'
+							name="email"
+							autoComplete="username"
 							className="form-control"
 							id="inputEmailRegisterForm"
 							placeholder='email'
@@ -67,6 +69,8 @@ export const RegisterForm = ({ activateAuth }) => {
 							id="inputPasswordRegisterForm"
 							placeholder='password'
 							type='password'
+							name="password"
+							autoComplete="new-password"
 							{...password}
 							required
 							pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])[0-9a-zA-Z!*^?+-_@#$%&]{8,}$"
@@ -81,6 +85,8 @@ export const RegisterForm = ({ activateAuth }) => {
 							id="inputRepeatPasswordRegisterForm"
 							placeholder='repeat password'
 							type='password'
+							name="repeatPassword"
+							autoComplete="new-password"
 							{...repeatPassword}
 							required
 							pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])[0-9a-zA-Z!*^?+-_@#$%&]{8,}$"

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -20,7 +20,9 @@ const regexPassword = new RegExp(/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])[0-9a-zA-Z!*^?+
 const regexQuantityOfMoney = new RegExp(/^\s*-?\d+(\.\d{1,2})?\s*$/)
 
 /**
- * Validate the login form data. This is useful for reduce traffic to backend
+ * Validate the login form data. This is useful for reduce traffic to backend.
+ * Password strength is not checked here: rejecting a stored password that does not
+ * match the current rules would lock out password managers. Only the backend decides
  * @param {string} email
  * @param {string} password
  * @returns {boolean}                - True means data is valid
@@ -36,9 +38,6 @@ const validateLoginForm = (email, password) => {
 		dataIsValid = false
 	}
 
-	if (!regexPassword.test(password)) {
-		dataIsValid = false
-	}
 	return dataIsValid
 }
 

--- a/src/utils/validations.test.js
+++ b/src/utils/validations.test.js
@@ -19,15 +19,15 @@ describe('validateLoginForm', () => {
 		expect(result).toBe(false)
 	})
 
-	test('should return false if password is not enough secure', () => {
+	test('should return true regardless of the password strength, because only the backend decides', () => {
 		const email = 'example@mail.com'
 
-		const listOfUnsecurePasswords = ['foo', '1234', 'blablabla', 'AAAAAAAAAAA', '*_*_*_*_*_*_*', '1aA*']
+		const listOfPasswordsRejectedOnRegistration = ['foo', '1234', 'blablabla', 'AAAAAAAAAAA', '*_*_*_*_*_*_*', '1aA*', 'w~mb(3Qz)tf']
 
-		listOfUnsecurePasswords.forEach(password => {
+		listOfPasswordsRejectedOnRegistration.forEach(password => {
 			const result = validateLoginForm(email, password)
 
-			expect(result).toBe(false)
+			expect(result).toBe(true)
 		})
 	})
 


### PR DESCRIPTION
## Why

On iOS, opening the app did not offer the saved credential (and therefore did not trigger Face ID) until the email field was tapped by hand.

The cause: neither the login nor the register form declared `name`, `type` or `autocomplete` on its fields. Safari decides whether to offer AutoFill **when the page loads**, using those attributes to recognise a username/password pair. Without them it falls back to a heuristic that only runs once a field is focused manually — exactly the behaviour observed. There was not a single `autoComplete` anywhere in `src/`.

## What changed

**`LoginForm`** — `type="email"`, `name="email"`, `autoComplete="username"` on the email field; `name="password"`, `autoComplete="current-password"` on the password field. Dropped `inputMode="email"`, now redundant with `type="email"`.

**`RegisterForm`** — the same on the email field, plus `name` and `autoComplete="new-password"` on both password fields, so the keychain offers to *generate* a password instead of filling the existing one.

**`validateLoginForm`** — no longer checks password strength. The charset enforced by the registration rules (`[0-9a-zA-Z!*^?+-_@#$%&]`) excludes characters a generated password may well contain (`~ ( ) { } | ' \"` and the backtick). A stored password containing one of those filled both fields but left the submit button disabled forever. Login has no business judging strength — that belongs to the register form, where `regexPassword` is still used, and to the backend.

**Both `<form>` elements** — removed the stray `disabled={isDisabled}`. `disabled` is not a valid attribute on `<form>` and did nothing; the inputs are already disabled individually.

`autoFocus` was deliberately left alone: iOS Safari ignores programmatic focus without a user gesture, so it is a no-op there and not part of this bug. Removing it would only have cost desktop users a click.

## Notes for the reviewer

- New test `should enable the button for a stored password that would not pass the registration rules` fails against the previous code — it covers the autofill lockout directly. The other new test pins the autofill attributes as a contract so they are not dropped again.
- The `validateLoginForm` strength test was inverted rather than deleted: those passwords must now be accepted.
- Password-field queries moved from `getByPlaceholderText` to `getByLabelText`, per the repo's testing rules.
- Verified in a real browser at 390px: both routes serve the expected attributes, focus still lands on the email field, layout unchanged. Lint clean, 333 tests pass.
- What CI cannot prove is that Face ID now fires on app open — that needs a real iPhone with the keychain. The attributes match what Apple documents. If it still waits for a tap, the next suspect is `/login` being lazy-loaded via `LazyRoute`, leaving the inputs absent from the DOM at the moment Safari makes its decision.