### PR TITLE
test: probe whether iOS autofill needs the login form at parse time

### DIFF
--- a/public/faceid-test.html
+++ b/public/faceid-test.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+	<title>Face ID autofill test</title>
+</head>
+
+<body>
+	<!--
+		Throwaway page. It exists to answer one question: does iOS Safari offer the
+		saved credential without any interaction when the login form is present in the
+		HTML at parse time, instead of being injected later by React?
+
+		It must be served from the production origin, because the keychain entry is
+		bound to it. Delete this file once the question is answered.
+	-->
+	<h1>Face ID autofill test</h1>
+	<p>Open this page and do not touch anything. Does the saved password get offered?</p>
+
+	<form action="/faceid-test.html" method="get">
+		<label for="email">Email</label>
+		<input type="email" name="email" id="email" autocomplete="username" required />
+
+		<label for="password">Password</label>
+		<input type="password" name="password" id="password" autocomplete="current-password" required />
+
+		<button type="submit">Log in</button>
+	</form>
+</body>
+
+</html>


### PR DESCRIPTION
## Why

Follow-up to #231. That PR added the correct `autocomplete` / `name` / `type` attributes to the credential forms, but Face ID still does not fire on opening the app — the email field has to be tapped first. Loading `/login` as a real document (rather than navigating there inside the SPA) did not change it either.

The likely reason: **the form does not exist in the HTML that Safari parses.** [`public/_redirects`](public/_redirects) serves `index.html` for every route, so `/login` returns just `<div id="root"></div>` plus the module script. React injects the form afterwards via `createRoot().render()`. By the time the inputs exist, Safari has already decided whether the document contains a login form worth offering a credential for.

Sites that do offer the credential with no interaction (MediaFire, for one — the counterexample that disproved my earlier "iOS always requires a gesture" conclusion) ship their form in the HTML.

## What this adds

A single throwaway static page, `public/faceid-test.html`, carrying the same email/password pair in the HTML itself — no JavaScript involved. Verified with `curl` that the inputs are present in the raw response.

**This is a probe, not a fix.** It gets deleted once the question is answered.

## Notes for the reviewer

- It has to reach **production**, not a deploy preview: the keychain entry is bound to `didibudget.netlify.app`, and a preview origin would offer nothing, making the result meaningless.
- The page is unlinked, self-contained, and touches nothing in `src/`. Its form submits `GET` to itself and there is no backend call.
- Test: open `https://didibudget.netlify.app/faceid-test.html` on the iPhone and touch nothing. Does the saved password get offered?
  - **Yes** → the deciding factor is parse-time presence. The real fix is prerendering `/login` at build time and switching `createRoot` to `hydrateRoot`, so React hydrates that markup instead of replacing it (replacing it would throw away exactly what we just gained). Contained to `vite.config.js` and `src/index.js`, but real build work — hence wanting the evidence first.
  - **No** → next suspect is the manifest's `"display": "standalone"`. AutoFill behaves differently in a home-screen app than in Safari proper, and that would be worth comparing side by side.
- Caveat worth stating plainly: two of my hypotheses have already been wrong. This is the difference I could confirm by reading the code, and it explains every observation so far, but it stays a hypothesis until this page settles it.