### PR TITLE
test: probe whether the autofill offer survives React remounting the markup

### DIFF
--- a/public/faceid-test-remount.html
+++ b/public/faceid-test-remount.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+	<title>Face ID autofill test: remount</title>
+</head>
+
+<body>
+	<!--
+		Throwaway page, companion to faceid-test.html.
+
+		faceid-test.html proved Safari offers the credential with no interaction when the
+		form is in the HTML at parse time. This page answers the follow-up: does that offer
+		survive React throwing the parsed markup away?
+
+		`createRoot(container).render(...)` empties the container and builds fresh nodes.
+		So here the form ships in the HTML exactly as before, and then a script empties the
+		container and rebuilds an identical form from scratch, which is what the real app
+		would do to prerendered markup.
+
+		If Face ID still fires and fills the rebuilt fields, prerendering plus a plain
+		createRoot is enough. If it does not, the fix has to use hydrateRoot so React adopts
+		the existing nodes instead of replacing them.
+
+		Delete this file once the question is answered.
+	-->
+	<h1>Face ID autofill test: remount</h1>
+	<p>Open this page and do not touch anything. The form below gets rebuilt from scratch shortly
+		after load. Does the saved password still get offered, and does it fill the fields?</p>
+
+	<div id="root">
+		<form id="login" method="post" action="/faceid-test-remount.html">
+			<label for="email">Email</label>
+			<input type="email" name="email" id="email" autocomplete="username" required />
+
+			<label for="password">Password</label>
+			<input type="password" name="password" id="password" autocomplete="current-password" required />
+
+			<button type="submit">Log in</button>
+		</form>
+	</div>
+
+	<p id="status">Waiting to rebuild the form…</p>
+
+	<script>
+		// Mimic what createRoot().render() does to server-rendered markup: drop every parsed
+		// node, then build equivalent ones. The delay stands in for parsing and running the
+		// app bundle on a phone.
+		setTimeout(function () {
+			var root = document.getElementById('root')
+			root.textContent = ''
+
+			var form = document.createElement('form')
+			form.id = 'login'
+			form.method = 'post'
+			form.action = '/faceid-test-remount.html'
+
+			var fields = [
+				{ label: 'Email', type: 'email', name: 'email', id: 'email', autocomplete: 'username' },
+				{ label: 'Password', type: 'password', name: 'password', id: 'password', autocomplete: 'current-password' }
+			]
+
+			fields.forEach(function (field) {
+				var label = document.createElement('label')
+				label.htmlFor = field.id
+				label.textContent = field.label
+
+				var input = document.createElement('input')
+				input.type = field.type
+				input.name = field.name
+				input.id = field.id
+				input.autocomplete = field.autocomplete
+				input.required = true
+
+				form.appendChild(label)
+				form.appendChild(input)
+			})
+
+			var button = document.createElement('button')
+			button.type = 'submit'
+			button.textContent = 'Log in'
+			form.appendChild(button)
+
+			root.appendChild(form)
+
+			document.getElementById('status').textContent = 'Form rebuilt from scratch.'
+		}, 400)
+	</script>
+</body>
+
+</html>


### PR DESCRIPTION
## Why

Follow-up to #232, which settled the root cause. Confirmed on device, in Safari, same origin, same saved credential:

| Page | Form in parsed HTML | Face ID with no interaction |
|---|---|---|
| `/login` (the SPA) | no — `<div id="root"></div>` only | no |
| `/faceid-test.html` | yes | **yes** |

So Safari decides at parse time, and the app's login form does not exist yet at that moment because React injects it afterwards.

Worth recording, because it disproves the assumption behind #231: MediaFire's login page — which does offer Face ID with no interaction — ships `autocomplete="off"` on its password field and no `autocomplete` at all on its email field. Safari deliberately ignores `autocomplete="off"` on password fields. The attributes added in #231 were therefore not the lever for this symptom. They stay, because they fixed a real bug (a generated password left the submit button permanently disabled) and they make the on-focus suggestion reliable, but they were not the cause.

## What this adds

One more throwaway page, `public/faceid-test-remount.html`. The fix will involve prerendering `/login` so the form is in the HTML — but `createRoot(container).render(...)` **empties its container and builds fresh nodes**, so prerendering on its own may hand Safari a form and then immediately destroy it.

This page ships the form in the HTML and then rebuilds it from scratch via script after 400ms, which is what the real app would do to prerendered markup.

- **Face ID still fires and fills** → prerender + plain `createRoot` is enough. Small change.
- **It does not** → the fix must use `hydrateRoot` so React adopts the parsed nodes instead of replacing them. Bigger change: hydration needs the whole tree to be SSR-safe, and `AuthContext` reads `sessionStorage` in a `useState` initializer, which does not exist during a build-time render.

Cheaper to ask the phone than to guess and rebuild the pipeline twice.

## Notes for the reviewer

- Same constraints as #232: it has to reach **production**, since the keychain entry is bound to `didibudget.netlify.app`. Unlinked, self-contained, nothing in `src/` touched.
- Verified locally: `curl` shows both inputs in the raw HTML, and after the script runs there is one form whose inputs are freshly built nodes carrying the same attributes.
- Test: open `https://didibudget.netlify.app/faceid-test-remount.html` in Safari, touch nothing, and watch whether the credential is still offered — and if accepted, whether the values land in the rebuilt fields.
- Both probe pages get deleted once the real fix lands.