### PR TITLE
fix: UI polish on the category picker and the search fields

### DIFF
--- a/src/components/Expenses/CategoryPicker/index.js
+++ b/src/components/Expenses/CategoryPicker/index.js
@@ -98,15 +98,15 @@ export const CategoryPicker = ({ categories, frequentCategories, selected, onSel
 				)
 			}
 
-			<p className="text-light small mb-1">All</p>
+			<p className="text-light small mb-0">All</p>
 
 			{
 				isFiltering
 					? (
 						<ul className="list-group list-group-flush">
 							{
-								filteredLeaves.map(leaf => (
-									<li className="list-group-item bg-dark border-info px-0" key={leaf.key}>
+								filteredLeaves.map((leaf, index) => (
+									<li className={`list-group-item bg-dark border-info px-0 ${index === 0 ? 'pt-0' : ''}`} key={leaf.key}>
 										<button type="button" className="btn btn-link text-start text-info p-0" onClick={() => chooseLeaf(leaf)}>
 											{leaf.label}
 										</button>
@@ -119,15 +119,16 @@ export const CategoryPicker = ({ categories, frequentCategories, selected, onSel
 					: (
 						<ul className="list-group list-group-flush">
 							{
-								categories.map(category => {
+								categories.map((category, index) => {
 									const hasSubcategories = Boolean(category.subcategories?.length)
 									const isExpanded = Boolean(expandedItems[category.uuid])
+									const itemClassName = `list-group-item bg-dark border-info px-0 ${index === 0 ? 'pt-0' : ''}`
 
 									if (!hasSubcategories) {
 										const leaf = buildLeaf(category, null)
 
 										return (
-											<li className="list-group-item bg-dark border-info px-0" key={category.uuid}>
+											<li className={itemClassName} key={category.uuid}>
 												<button
 													type="button"
 													className="btn btn-link text-start text-info p-0"
@@ -143,7 +144,7 @@ export const CategoryPicker = ({ categories, frequentCategories, selected, onSel
 									const categoryLeaf = buildLeaf(category, null)
 
 									return (
-										<li className="list-group-item bg-dark border-info px-0" key={category.uuid}>
+										<li className={itemClassName} key={category.uuid}>
 											<button
 												type="button"
 												className="btn btn-link text-start text-info p-0 d-inline-flex align-items-center"

--- a/src/components/Expenses/CategoryPicker/index.js
+++ b/src/components/Expenses/CategoryPicker/index.js
@@ -79,7 +79,7 @@ export const CategoryPicker = ({ categories, frequentCategories, selected, onSel
 			{
 				!isFiltering && frequentLeaves.length > 0 && (
 					<div className="mb-3">
-						<p className="text-light small mb-1">Frequent</p>
+						<p className="text-light small mb-1">Most used</p>
 						<div className="d-flex flex-wrap gap-2">
 							{
 								frequentLeaves.map(leaf => (
@@ -98,7 +98,7 @@ export const CategoryPicker = ({ categories, frequentCategories, selected, onSel
 				)
 			}
 
-			<p className="text-light small mb-0">All</p>
+			<p className="text-light small mb-0">All categories</p>
 
 			{
 				isFiltering

--- a/src/components/Expenses/CategoryPicker/index.js
+++ b/src/components/Expenses/CategoryPicker/index.js
@@ -1,6 +1,6 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
-import { BsFillCaretDownFill, BsFillCaretUpFill } from 'react-icons/bs'
+import { BsFillCaretDownFill, BsFillCaretUpFill, BsX } from 'react-icons/bs'
 
 import { EmojiListFromCategoryOrSubcategory } from '../../EmojiListFromCategoryOrSubcategory'
 
@@ -30,6 +30,7 @@ export const CategoryPicker = ({ categories, frequentCategories, selected, onSel
 	const [filterText, setFilterText] = useState('')
 	const [expandedItems, setExpandedItems] = useState({})
 	const [isChanging, setIsChanging] = useState(false)
+	const filterInput = useRef(null)
 
 	const leaves = useMemo(() => flattenCategories(categories), [categories])
 	const frequentLeaves = useMemo(() => frequentCategories.map(buildFrequentLeaf), [frequentCategories])
@@ -39,6 +40,11 @@ export const CategoryPicker = ({ categories, frequentCategories, selected, onSel
 
 	const toggleItem = (uuid) => {
 		setExpandedItems((previous) => ({ ...previous, [uuid]: !previous[uuid] }))
+	}
+
+	const clearFilter = () => {
+		setFilterText('')
+		filterInput.current.focus()
 	}
 
 	const chooseLeaf = (leaf) => {
@@ -66,15 +72,32 @@ export const CategoryPicker = ({ categories, frequentCategories, selected, onSel
 
 	return (
 		<div>
-			<input
-				id="categoryPickerFilter"
-				type="search"
-				className="form-control mb-3"
-				placeholder="Search…"
-				aria-label="Filter categories"
-				value={filterText}
-				onChange={(event) => setFilterText(event.target.value)}
-			/>
+			<div className="input-group mb-3">
+				<input
+					id="categoryPickerFilter"
+					type="text"
+					inputMode="search"
+					enterKeyHint="search"
+					className="form-control"
+					placeholder="Search…"
+					aria-label="Filter categories"
+					value={filterText}
+					onChange={(event) => setFilterText(event.target.value)}
+					ref={filterInput}
+				/>
+				{
+					(filterText !== '') && (
+						<button
+							type="button"
+							className="btn btn-light"
+							aria-label="Clear filter"
+							onClick={clearFilter}
+						>
+							<BsX size={'24px'} />
+						</button>
+					)
+				}
+			</div>
 
 			{
 				!isFiltering && frequentLeaves.length > 0 && (

--- a/src/components/Expenses/CategoryPicker/index.test.js
+++ b/src/components/Expenses/CategoryPicker/index.test.js
@@ -71,7 +71,7 @@ describe('CategoryPicker', () => {
 	it('hides the frequent section when there are no frequent categories', () => {
 		renderPicker({ frequentCategories: [] })
 
-		expect(screen.queryByText('Frequent')).not.toBeInTheDocument()
+		expect(screen.queryByText('Most used')).not.toBeInTheDocument()
 	})
 
 	it('lists the categories as an accordion while the filter is empty', () => {

--- a/src/components/Expenses/CategoryPicker/index.test.js
+++ b/src/components/Expenses/CategoryPicker/index.test.js
@@ -131,6 +131,34 @@ describe('CategoryPicker', () => {
 		expect(screen.queryByRole('button', { name: /Taxes/ })).not.toBeInTheDocument()
 	})
 
+	it('hides the clear button while the filter is empty', () => {
+		renderPicker({ frequentCategories: [] })
+
+		expect(screen.queryByRole('button', { name: 'Clear filter' })).not.toBeInTheDocument()
+	})
+
+	it('restores the accordion when the filter is cleared', async () => {
+		const user = userEvent.setup()
+		renderPicker({ frequentCategories: [] })
+		await user.type(screen.getByLabelText('Filter categories'), 'fue')
+
+		await user.click(screen.getByRole('button', { name: 'Clear filter' }))
+
+		expect(screen.getByLabelText('Filter categories')).toHaveValue('')
+		expect(screen.queryByRole('button', { name: 'Private vehicles › Fuel' })).not.toBeInTheDocument()
+		expect(screen.getByRole('button', { name: /Taxes/ })).toBeVisible()
+	})
+
+	it('returns the focus to the filter input after clearing', async () => {
+		const user = userEvent.setup()
+		renderPicker({ frequentCategories: [] })
+		await user.type(screen.getByLabelText('Filter categories'), 'fue')
+
+		await user.click(screen.getByRole('button', { name: 'Clear filter' }))
+
+		expect(screen.getByLabelText('Filter categories')).toHaveFocus()
+	})
+
 	it('collapses the list once a category is selected', () => {
 		renderPicker({ selected: { categoryID: 'category-id-2', subcategoryID: null } })
 

--- a/src/components/Users/ListOfUsers/index.js
+++ b/src/components/Users/ListOfUsers/index.js
@@ -1,5 +1,6 @@
-import { Fragment, useEffect, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
+import { BsX } from 'react-icons/bs'
 
 import { roleBadge, statusBadge } from './badges'
 import { formatTimeAgo } from './formatters'
@@ -7,6 +8,7 @@ import { UserListItemCard } from './UserListItemCard'
 
 export const ListOfUsers = ({ users, startPolling, stopPolling }) => {
 	const [search, setSearch] = useState('')
+	const searchInput = useRef(null)
 
 	useEffect(() => {
 		const minuteInMilliseconds = 60000
@@ -18,6 +20,11 @@ export const ListOfUsers = ({ users, startPolling, stopPolling }) => {
 		}
 	}, [startPolling, stopPolling])
 
+	const clearSearch = () => {
+		setSearch('')
+		searchInput.current.focus()
+	}
+
 	const filteredUsers = users.filter(user =>
 		user.email.toLowerCase().includes(search.toLowerCase())
 	)
@@ -26,15 +33,32 @@ export const ListOfUsers = ({ users, startPolling, stopPolling }) => {
 		<section>
 			<div className="row mb-4">
 				<div className="col-12 col-md-6 col-lg-4">
-					<input
-						id="searchUsersByEmail"
-						type="search"
-						className="form-control"
-						placeholder="Search by email..."
-						aria-label="Search by email"
-						value={search}
-						onChange={(e) => setSearch(e.target.value)}
-					/>
+					<div className="input-group">
+						<input
+							id="searchUsersByEmail"
+							type="text"
+							inputMode="search"
+							enterKeyHint="search"
+							className="form-control"
+							placeholder="Search by email..."
+							aria-label="Search by email"
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+							ref={searchInput}
+						/>
+						{
+							(search !== '') && (
+								<button
+									type="button"
+									className="btn btn-outline-secondary"
+									aria-label="Clear search"
+									onClick={clearSearch}
+								>
+									<BsX size={'24px'} />
+								</button>
+							)
+						}
+					</div>
 				</div>
 			</div>
 

--- a/src/components/Users/ListOfUsers/index.js
+++ b/src/components/Users/ListOfUsers/index.js
@@ -50,7 +50,7 @@ export const ListOfUsers = ({ users, startPolling, stopPolling }) => {
 							(search !== '') && (
 								<button
 									type="button"
-									className="btn btn-outline-secondary"
+									className="btn btn-light"
 									aria-label="Clear search"
 									onClick={clearSearch}
 								>

--- a/src/components/Users/ListOfUsers/index.test.js
+++ b/src/components/Users/ListOfUsers/index.test.js
@@ -44,7 +44,9 @@ const renderList = (users = mockUsers) => {
 
 const getTable = () => within(screen.getByRole('table'))
 
-const getSearchInput = () => screen.getByRole('searchbox', { name: 'Search by email' })
+const getSearchInput = () => screen.getByRole('textbox', { name: 'Search by email' })
+
+const getClearButton = () => screen.getByRole('button', { name: 'Clear search' })
 
 describe('ListOfUsers', () => {
 	beforeEach(() => {
@@ -123,6 +125,42 @@ describe('ListOfUsers', () => {
 
 		expect(getTable().getByText('bob@example.com')).toBeVisible()
 		expect(screen.queryByText('alice@example.com')).not.toBeInTheDocument()
+	})
+
+	it('hides the clear button while the search is empty', () => {
+		renderList()
+
+		expect(screen.queryByRole('button', { name: 'Clear search' })).not.toBeInTheDocument()
+	})
+
+	it('offers a clear button once something is typed', async () => {
+		const user = userEvent.setup()
+		renderList()
+
+		await user.type(getSearchInput(), 'alice')
+
+		expect(getClearButton()).toBeVisible()
+	})
+
+	it('empties the search and restores every user when the clear button is used', async () => {
+		const user = userEvent.setup()
+		renderList()
+		await user.type(getSearchInput(), 'alice')
+
+		await user.click(getClearButton())
+
+		expect(getSearchInput()).toHaveValue('')
+		expect(getTable().getByText('bob@example.com')).toBeVisible()
+	})
+
+	it('returns the focus to the search input after clearing', async () => {
+		const user = userEvent.setup()
+		renderList()
+		await user.type(getSearchInput(), 'alice')
+
+		await user.click(getClearButton())
+
+		expect(getSearchInput()).toHaveFocus()
 	})
 
 	it('shows a no results message when search matches nothing', async () => {


### PR DESCRIPTION
Small UI/UX fixes spotted while using the app on the phone. Nothing here changes behaviour beyond the search fields gaining a clear button.

## Category picker (`/spending/add`)

- **Spacing under the group label.** The label used `mb-1` and the first `.list-group-item` kept Bootstrap's 8px top padding, so there was twice as much air under it as under the chips group. The first row now drops its top padding. This costs no touch area: the tap target is the `btn-link`, never the `li` padding.
- **Group labels renamed.** "Frequent" / "All" were not parallel, and "Frequent" did not describe the actual rule — the chips are the six most used categories of the last 90 days. They are now **"Most used"** / **"All categories"**.

## Search fields

Both search inputs were `type="search"` and relied on the browser's native cancel button. iOS Safari never paints it, so on the phone the only way to empty either field was the keyboard, while desktop Chrome did show an X on focus. Bootstrap's Reboot does not help here — it normalises `[type=search]` rendering, it does not add controls.

Both fields are now plain text inputs with `inputMode="search"` and `enterKeyHint="search"` (so the phone still offers the search keyboard) plus an owned clear button, shown only when there is text. Clearing returns focus to the input so the mobile keyboard stays open.

This affects the user search in `ListOfUsers` and the category filter in `CategoryPicker`. The category filter is the more useful of the two: filtering hides the accordion, so getting the full list back previously required clearing the field by hand.

## Notes for review

- The clear button is `btn-light`, which merges it with the white field the way a native search field does. The first attempt used `btn-outline-secondary`, whose icon is Bootstrap's muted grey at 3.29:1 over the page background — it read as disabled. This one is ~18:1.
- In `CategoryPicker` the button is conditioned on `filterText !== ''` rather than the existing `isFiltering`, which trims: with only spaces typed, the filter is inactive but the field is not empty and still needs clearing.
- Changing `type` moves the input's implicit role from `searchbox` to `textbox`; the `ListOfUsers` test helper was updated accordingly. The `CategoryPicker` tests query by label, so they were unaffected.
- Seven new tests cover the clear button on both fields, including focus return. Full suite: 340 passing.
- Everything was checked in the browser at 390px.