### PR TITLE
Stop showing empty states as errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,9 +79,12 @@ GraphQL queries return `{ data, loading, error }`. Example pattern:
 ```javascript
 const { data, loading, error } = useQuery(QUERY_NAME)
 if (loading) return <Spinner />
-if (error) return <ErrorAlert error={error} />
+if (error) return <ErrorAlert errorMessage={error.message} />
 // Use data...
 ```
+
+`ErrorAlert` (red, `role="alert"`) is only for failures: network, GraphQL, form validation. For "no data
+yet" or "no results" use `EmptyState` (`role="status"`). Never use `ErrorAlert` for an empty list.
 
 ### Mutations
 Mutations typically use `useMutation` hook with error/success handling.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,9 @@ majority to weigh against a desktop minority — it is where the app is used.
 The page is dark but form controls are **not**: the app uses default Bootstrap `form-control` /
 `form-select` with no colour overrides. Match that in new forms.
 
+`ErrorAlert` (red, `role="alert"`) is only for failures: network, GraphQL, form validation. For "no data
+yet" or "no results" use `EmptyState` (`role="status"`). Never use `ErrorAlert` for an empty list.
+
 ## Commands
 
 ```bash
@@ -54,7 +57,7 @@ Requires Node 24.14 (see `.nvmrc`). Copy `_env` to `.env` and set `VITE_PROTOCOL
 - **Apollo** (`src/apollo/config.js`): a link chain — `authMiddleware` (attaches `Bearer <token>` from session) → `errorLink` (on `UNAUTHENTICATED`/`FORBIDDEN` graphQL errors or `invalid_token` network errors, clears session and hard-redirects to `/`; rewrites `INTERNAL_SERVER_ERROR` messages) → `httpLink`. Changing this affects every API call.
 - **Routing** (`src/App.js`): React Router 7. There is no outer `<Suspense>` — every lazily-loaded screen must be wrapped in `<LazyRoute>` (`src/components/LazyRoute/index.js`), inside its guard. Routes are guarded by wrapper components `RequireAuth`, `RequireUnauthenticated`, and `RequireAdminRole` (admin routes nest `RequireAdminRole` inside `RequireAuth`). Paths are `/<resource-singular>/<action-or-view>` and must reuse the wording of the page title and NavBar label — the UI says *spending*, so URLs say `spending`, never `expense`.
 - **GraphQL** (`src/gql/`): `queries/` and `mutations/` split by entity (expenses, users, monthlyBalances, expenseCategories, auth). Operations are named exports (e.g. `LIST_ALL_EXPENSES`).
-- **Data-fetching components**: under `src/components/<Entity>/`, files named `Get*.js` (e.g. `GetListOfExpensesWithPagination.js`) wrap a `useQuery`/`useMutation` and handle loading/error, keeping fetching separate from presentation. Standard pattern: `if (loading) return <Spinner />; if (error) return <ErrorAlert error={error} />`.
+- **Data-fetching components**: under `src/components/<Entity>/`, files named `Get*.js` (e.g. `GetListOfExpensesWithPagination.js`) wrap a `useQuery`/`useMutation` and handle loading/error, keeping fetching separate from presentation. Standard pattern: `if (loading) return <Spinner />; if (error) return <ErrorAlert errorMessage={error.message} />`.
 - **pages/** are route-level screens; **components/** are reusable UI (each usually an `index.js`, often with a colocated `index.test.js`).
 
 ## Testing notes

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -40,7 +40,8 @@ describe('App routing', () => {
 	it('shows the not found screen for an unknown url', () => {
 		renderAppAt('/this-route-does-not-exist')
 
-		expect(screen.getByRole('alert')).toHaveTextContent('404')
+		expect(screen.getByRole('heading', { name: 'Page not found' })).toBeVisible()
+		expect(screen.getByRole('link', { name: 'Go to the home page' })).toBeVisible()
 	})
 
 	it('shows the login screen to a visitor without a session', () => {

--- a/src/components/EmptyState/index.js
+++ b/src/components/EmptyState/index.js
@@ -1,0 +1,9 @@
+import PropTypes from 'prop-types'
+
+export const EmptyState = ( { message } ) => (
+	<p className="alert alert-info py-3 text-center my-5" role="status">{message}</p>
+)
+
+EmptyState.propTypes = {
+	message: PropTypes.string.isRequired
+}

--- a/src/components/EmptyState/index.test.js
+++ b/src/components/EmptyState/index.test.js
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react'
+
+import { EmptyState } from './'
+
+describe('EmptyState', () => {
+	it('announces the message politely instead of as an alert', () => {
+		render(<EmptyState message='No expenses recorded yet' />)
+
+		expect(screen.getByRole('status')).toBeVisible()
+		expect(screen.getByRole('status')).toHaveTextContent('No expenses recorded yet')
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+	})
+})

--- a/src/components/Expenses/AnalysisOfExpenses/index.js
+++ b/src/components/Expenses/AnalysisOfExpenses/index.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 
 import { getDetailedExpensesPerMonth } from '../utils'
 
-import { ErrorAlert } from '../../ErrorAlert'
+import { EmptyState } from '../../EmptyState'
 import { DetailedExpensesGroup } from '../DetailedExpensesGroup'
 
 export const AnalysisOfExpenses = ( { expenses, categories } ) => {
@@ -22,8 +22,8 @@ export const AnalysisOfExpenses = ( { expenses, categories } ) => {
 			</section>
 		)
 	} else {
-		const errorMessage = 'Not enough data'
-		return <ErrorAlert errorMessage={errorMessage} />
+		const message = 'No expenses recorded in this period'
+		return <EmptyState message={message} />
 	}
 }
 

--- a/src/components/Expenses/DateRangeExpenseOverview/index.js
+++ b/src/components/Expenses/DateRangeExpenseOverview/index.js
@@ -2,15 +2,15 @@ import PropTypes from 'prop-types'
 
 import { getDetailedExpensesGroupedFromRange } from '../utils'
 
-import { ErrorAlert } from '../../ErrorAlert'
+import { EmptyState } from '../../EmptyState'
 import { DetailedExpensesGroup } from '../DetailedExpensesGroup'
 
 export const DateRangeExpenseOverview = ({ startDate, endDate, expenses, categories }) => {
 	const expensesGroupedData = getDetailedExpensesGroupedFromRange(expenses, startDate, endDate)
 
 	if (!expensesGroupedData) {
-		const errorMessage = 'Not enough data'
-		return <ErrorAlert errorMessage={errorMessage} />
+		const message = 'No expenses recorded in this date range'
+		return <EmptyState message={message} />
 	}
 
 	return (

--- a/src/components/Expenses/GraphExpensesData/index.js
+++ b/src/components/Expenses/GraphExpensesData/index.js
@@ -5,7 +5,7 @@ import { ResponsiveContainer, BarChart, XAxis, YAxis, CartesianGrid, Tooltip, Ba
 import { parseUnixTimestamp } from '../../../utils/utils'
 import { getSumPerMonth, getLastNValuesFromArrayIfTheyExist } from '../utils'
 
-import { ErrorAlert } from '../../ErrorAlert'
+import { EmptyState } from '../../EmptyState'
 import { PageSubTitle } from '../../PageSubTitle'
 import { AveragePerMonth } from '../AveragePerMonth'
 
@@ -71,8 +71,8 @@ export const GraphExpensesData = ({ graphData, averageData, averageDataExcluding
 			</Fragment>
 		)
 	} else {
-		const errorMessage = 'Not enough data to generate statistics'
-		return <ErrorAlert errorMessage={errorMessage} />
+		const message = 'Not enough data yet to show spending statistics'
+		return <EmptyState message={message} />
 	}
 }
 

--- a/src/components/Expenses/ListOfExpenses/index.js
+++ b/src/components/Expenses/ListOfExpenses/index.js
@@ -65,7 +65,7 @@ export const ListOfExpenses = ( { expenses, paginationData, categories, refetch,
 			</section>
 		)
 	} else {
-		const message = 'No expenses recorded yet — add your first one to see the list'
+		const message = 'No expenses recorded yet. Add your first one to see the list'
 		return <EmptyState message={message} />
 	}
 }

--- a/src/components/Expenses/ListOfExpenses/index.js
+++ b/src/components/Expenses/ListOfExpenses/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import { parseUnixTimestamp } from '../../../utils/utils'
 import { getNameOfCategoryOrSubcategory } from '../utils'
 
-import { ErrorAlert } from '../../ErrorAlert'
+import { EmptyState } from '../../EmptyState'
 import { ButtonDelete } from '../../ButtonDelete'
 import { PaginateNavbar } from '../../PaginateNavbar'
 
@@ -65,8 +65,8 @@ export const ListOfExpenses = ( { expenses, paginationData, categories, refetch,
 			</section>
 		)
 	} else {
-		const errorMessage = 'Not enough data to generate list'
-		return <ErrorAlert errorMessage={errorMessage} />
+		const message = 'No expenses recorded yet — add your first one to see the list'
+		return <EmptyState message={message} />
 	}
 }
 

--- a/src/components/Expenses/SearchExpensesResults/index.js
+++ b/src/components/Expenses/SearchExpensesResults/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { parseUnixTimestamp } from '../../../utils/utils'
 import { getNameOfCategoryOrSubcategory } from '../utils'
 
-import { ErrorAlert } from '../../ErrorAlert'
+import { EmptyState } from '../../EmptyState'
 import { PaginateNavbar } from '../../PaginateNavbar'
 
 const DATE_LENGTH = 10
@@ -35,7 +35,7 @@ export const SearchExpensesResults = ({ searchResult, categories, onChangePage }
 	const { expenses, pagination, totalSum, currencyISO, breakdown } = searchResult
 
 	if (!expenses.length) {
-		return <ErrorAlert errorMessage='No expenses found' />
+		return <EmptyState message='No expenses match this search — try adjusting the filters' />
 	}
 
 	return (

--- a/src/components/Expenses/SearchExpensesResults/index.js
+++ b/src/components/Expenses/SearchExpensesResults/index.js
@@ -35,7 +35,7 @@ export const SearchExpensesResults = ({ searchResult, categories, onChangePage }
 	const { expenses, pagination, totalSum, currencyISO, breakdown } = searchResult
 
 	if (!expenses.length) {
-		return <EmptyState message='No expenses match this search — try adjusting the filters' />
+		return <EmptyState message='No expenses match this search. Try adjusting the filters' />
 	}
 
 	return (

--- a/src/components/Expenses/SearchExpensesResults/index.test.js
+++ b/src/components/Expenses/SearchExpensesResults/index.test.js
@@ -118,7 +118,7 @@ describe('SearchExpensesResults', () => {
 		expect(screen.queryByText('Delete')).not.toBeInTheDocument()
 	})
 
-	it('should display an alert when the search returns no expenses', () => {
+	it('should tell the user nothing matched when the search returns no expenses', () => {
 		const emptyResult = {
 			...searchResult,
 			expenses: [],
@@ -129,6 +129,6 @@ describe('SearchExpensesResults', () => {
 
 		render(<SearchExpensesResults searchResult={emptyResult} categories={categories} onChangePage={vi.fn()} />)
 
-		expect(screen.getByText('No expenses found')).toBeVisible()
+		expect(screen.getByRole('status')).toHaveTextContent('No expenses match this search')
 	})
 })

--- a/src/components/MonthlyBalance/GraphMonthlyBalance/index.js
+++ b/src/components/MonthlyBalance/GraphMonthlyBalance/index.js
@@ -4,7 +4,7 @@ import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tool
 
 import { parseUnixTimestamp } from '../../../utils/utils'
 
-import { ErrorAlert } from '../../ErrorAlert'
+import { EmptyState } from '../../EmptyState'
 import { PageSubTitle } from '../../PageSubTitle'
 import { InformativeBadge } from '../../InformativeBadge'
 
@@ -103,8 +103,8 @@ export const GraphMonthlyBalance = ({ data }) => {
 			</div>
 		)
 	} else {
-		const errorMessage = 'Not enough data to generate statistics'
-		return <ErrorAlert errorMessage={errorMessage} />
+		const message = 'Not enough data yet to show the balance chart'
+		return <EmptyState message={message} />
 	}
 }
 

--- a/src/components/MonthlyBalance/ListOfMonthlyBalances/index.js
+++ b/src/components/MonthlyBalance/ListOfMonthlyBalances/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import { parseUnixTimestamp } from '../../../utils/utils'
 
-import { ErrorAlert } from '../../ErrorAlert'
+import { EmptyState } from '../../EmptyState'
 import { ButtonDelete } from '../../ButtonDelete'
 import { PaginateNavbar } from '../../PaginateNavbar'
 
@@ -60,8 +60,8 @@ export const ListOfMonthlyBalances = ({ monthlyBalances, paginationData, refetch
 			</section>
 		)
 	} else {
-		const errorMessage = 'Not enough data to generate list'
-		return <ErrorAlert errorMessage={errorMessage} />
+		const message = 'No monthly balances recorded yet — add your first one to see the list'
+		return <EmptyState message={message} />
 	}
 }
 

--- a/src/components/MonthlyBalance/ListOfMonthlyBalances/index.js
+++ b/src/components/MonthlyBalance/ListOfMonthlyBalances/index.js
@@ -60,7 +60,7 @@ export const ListOfMonthlyBalances = ({ monthlyBalances, paginationData, refetch
 			</section>
 		)
 	} else {
-		const message = 'No monthly balances recorded yet — add your first one to see the list'
+		const message = 'No monthly balances recorded yet. Add your first one to see the list'
 		return <EmptyState message={message} />
 	}
 }

--- a/src/pages/Page404.js
+++ b/src/pages/Page404.js
@@ -7,6 +7,6 @@ export const Page404 = () => (
 	<Fragment>
 		<PageTitle text='Page not found' />
 		<p className="text-light">The page you are looking for does not exist or has been moved.</p>
-		<Link to='/' className="btn btn-primary">Go to the home page</Link>
+		<Link to='/' className="btn btn-outline-info">Go to the home page</Link>
 	</Fragment>
 )

--- a/src/pages/Page404.js
+++ b/src/pages/Page404.js
@@ -1,14 +1,12 @@
 import { Fragment } from 'react'
+import { Link } from 'react-router'
 
-import { ErrorAlert } from '../components/ErrorAlert'
-import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { PageTitle } from '../components/PageTitle'
 
-export const Page404 = () => {
-	useDocumentTitle('Page not found')
-
-	return (
-		<Fragment>
-			<ErrorAlert errorMessage='404' />
-		</Fragment>
-	)
-}
+export const Page404 = () => (
+	<Fragment>
+		<PageTitle text='Page not found' />
+		<p className="text-light">The page you are looking for does not exist or has been moved.</p>
+		<Link to='/' className="btn btn-primary">Go to the home page</Link>
+	</Fragment>
+)


### PR DESCRIPTION
## What

`ErrorAlert` (a red `alert-danger` with `role="alert"`) was covering three different situations. This branch leaves it doing only one of them.

- New `EmptyState` component: `alert-info`, `role="status"`, one required `message` prop. Same shape as `ErrorAlert`, which it sits next to.
- The seven "there is no data" screens now use it: the two admin lists, the two charts, the monthly breakdown, the date-range overview and the search results.
- The 404 page is a real page now. It used to render a red alert whose entire text was `404` — no explanation, no way out. It now has a title, a sentence, and a link home.
- Fixed a pre-existing documentation bug: both `CLAUDE.md` and `AGENTS.md` documented the component as `<ErrorAlert error={error} />`, but the prop is `errorMessage` and it takes a string. Copying that snippet produced a PropTypes warning and an empty alert. Both files also gained the rule for choosing between the two components.

`ErrorAlert` itself is untouched. It goes from 30 rendered uses to 22, all of them Apollo query failures or form validation.

## Why

Searching and finding nothing is normal behaviour, not a failure, and painting it red says the app is broken when it is working. The accessibility side matters too: `role="alert"` is an assertive live region, so a screen reader interrupts whatever it is saying. That is right for a network error and wrong for "no expenses this month" — hence `role="status"`, which is polite.

## For the reviewer

- Checked in a real browser at 390px, the viewport this app is actually used at: the 404 page and the search empty state, both with no horizontal overflow and copy that wraps without breaking words. `alert-info` resolves to `#055160` on `#cff4fc`, Bootstrap's own pairing, and reads clearly as informational next to the red.
- The 404 button uses `btn-outline-info` rather than `btn-primary`: the cyan accent is what every other button in the app uses, and `btn-primary` appeared nowhere else in the codebase.
- Six of the seven migrated components have no test files, and this branch deliberately does not add any — the edits are a one-line component swap inside an untouched `else` branch. That coverage gap is pre-existing and is not made worse here.
- Suite 341/341, lint clean, build OK.