### PR TITLE
test: cover session, auth context, apollo links and the delete confirmation

### DIFF
--- a/src/AuthContext.test.js
+++ b/src/AuthContext.test.js
@@ -1,0 +1,107 @@
+import { useContext } from 'react'
+import { renderHook, act } from '@testing-library/react'
+
+import Auth, { AuthContext } from './AuthContext'
+
+const toBase64Url = (obj) => btoa(JSON.stringify(obj))
+	.replace(/\+/g, '-')
+	.replace(/\//g, '_')
+	.replace(/=+$/, '')
+
+const makeToken = (payload) => `aGVhZGVy.${toBase64Url(payload)}.c2lnbmF0dXJl`
+
+const anAdmin = {
+	email: 'admin@mail.com',
+	isAdmin: true,
+	isActive: true,
+	registrationDate: 1715776800000,
+	uuid: 'abc-123'
+}
+
+const renderAuth = () => renderHook(() => useContext(AuthContext), { wrapper: Auth.Provider })
+
+describe('AuthContext', () => {
+	beforeEach(() => {
+		sessionStorage.clear()
+	})
+
+	it('starts signed out when there is no stored session', () => {
+		const { result } = renderAuth()
+
+		expect(result.current.isAuth).toBeFalsy()
+		expect(result.current.userData).toEqual({})
+	})
+
+	it('signs the user in with the claims carried by the token', () => {
+		const { result } = renderAuth()
+
+		act(() => result.current.activateAuth(makeToken(anAdmin)))
+
+		expect(result.current.isAuth).toBe(true)
+		expect(result.current.userData.email).toBe('admin@mail.com')
+		expect(result.current.userData.isAdmin).toBe(true)
+		expect(result.current.userData.uuid).toBe('abc-123')
+	})
+
+	it('keeps the session across a page reload', () => {
+		const { result, unmount } = renderAuth()
+		act(() => result.current.activateAuth(makeToken(anAdmin)))
+		unmount()
+
+		const { result: afterReload } = renderAuth()
+
+		expect(afterReload.current.isAuth).toBeTruthy()
+		expect(afterReload.current.userData.email).toBe('admin@mail.com')
+	})
+
+	it('still recognises an admin after a page reload', () => {
+		const { result, unmount } = renderAuth()
+		act(() => result.current.activateAuth(makeToken(anAdmin)))
+		unmount()
+
+		const { result: afterReload } = renderAuth()
+
+		expect(afterReload.current.userData.isAdmin).toBe(true)
+	})
+
+	it('does not hand out admin rights to a regular user after a reload', () => {
+		const { result, unmount } = renderAuth()
+		act(() => result.current.activateAuth(makeToken({ ...anAdmin, isAdmin: false })))
+		unmount()
+
+		const { result: afterReload } = renderAuth()
+
+		expect(afterReload.current.userData.isAdmin).toBe(false)
+	})
+
+	it('signs the user out and forgets everything about them', () => {
+		const { result } = renderAuth()
+		act(() => result.current.activateAuth(makeToken(anAdmin)))
+
+		act(() => result.current.removeAuth())
+
+		expect(result.current.isAuth).toBe(false)
+		expect(result.current.userData).toEqual({})
+		expect(sessionStorage.getItem('token')).toBeNull()
+		expect(sessionStorage.getItem('userData')).toBeNull()
+	})
+
+	it('does not blow up on a token it cannot read', () => {
+		const { result } = renderAuth()
+
+		act(() => result.current.activateAuth('not-a-jwt'))
+
+		expect(result.current.userData.email).toBeUndefined()
+	})
+
+	it('turns the registration date into a string once the session is reloaded', () => {
+		const { result, unmount } = renderAuth()
+		act(() => result.current.activateAuth(makeToken(anAdmin)))
+		expect(result.current.userData.registrationDate).toBe(1715776800000)
+		unmount()
+
+		const { result: afterReload } = renderAuth()
+
+		expect(afterReload.current.userData.registrationDate).toBe('1715776800000')
+	})
+})

--- a/src/apollo/config.js
+++ b/src/apollo/config.js
@@ -1,6 +1,6 @@
 import { ApolloClient, InMemoryCache, HttpLink, ApolloLink } from '@apollo/client'
 import { onError } from '@apollo/client/link/error'
-import { recoverSession, deleteSession } from '../utils/session'
+import { recoverSession, forceSessionExpiry } from '../utils/session'
 
 /* Configuration imported from '.env' file (Vite env vars: import.meta.env.VITE_*) */
 const backendProtocol 	= import.meta.env.VITE_PROTOCOL
@@ -14,7 +14,7 @@ const httpLink = new HttpLink({
 	uri: backendAddress
 })
 
-const authMiddleware = new ApolloLink((operation, forward) => {
+export const authMiddleware = new ApolloLink((operation, forward) => {
 	const token = recoverSession('token')
 	const authorization = token ? `Bearer ${token}` : ''
 	operation.setContext(({ headers = {} }) => ({
@@ -27,13 +27,12 @@ const authMiddleware = new ApolloLink((operation, forward) => {
 	return forward(operation)
 })
 
-const errorLink = onError(({ operation, graphQLErrors, networkError, response }) => {
+export const errorLink = onError(({ operation, graphQLErrors, networkError, response }) => {
 	if (graphQLErrors) {
 		graphQLErrors.forEach(err => {
 			// err.message, err.locations, err.path, err.extensions
 			if (err.extensions.code === 'UNAUTHENTICATED' || err.extensions.code === 'FORBIDDEN') {
-				deleteSession()
-				window.location.href = '/'
+				forceSessionExpiry()
 			}
 
 			if (err.extensions.code === 'INTERNAL_SERVER_ERROR') {
@@ -43,8 +42,7 @@ const errorLink = onError(({ operation, graphQLErrors, networkError, response })
 	}
 
 	if (networkError && networkError.response === 'invalid_token') {
-		deleteSession()
-		window.location.href = '/'
+		forceSessionExpiry()
 	}
 })
 

--- a/src/apollo/config.js
+++ b/src/apollo/config.js
@@ -31,11 +31,11 @@ export const errorLink = onError(({ operation, graphQLErrors, networkError, resp
 	if (graphQLErrors) {
 		graphQLErrors.forEach(err => {
 			// err.message, err.locations, err.path, err.extensions
-			if (err.extensions.code === 'UNAUTHENTICATED' || err.extensions.code === 'FORBIDDEN') {
+			if (err.extensions?.code === 'UNAUTHENTICATED' || err.extensions?.code === 'FORBIDDEN') {
 				forceSessionExpiry()
 			}
 
-			if (err.extensions.code === 'INTERNAL_SERVER_ERROR') {
+			if (err.extensions?.code === 'INTERNAL_SERVER_ERROR') {
 				err.message = 'An error has occurred'
 			}
 		})

--- a/src/apollo/config.test.js
+++ b/src/apollo/config.test.js
@@ -1,0 +1,128 @@
+import { ApolloLink, Observable, execute, gql } from '@apollo/client'
+
+import { authMiddleware, errorLink } from './config'
+import { recoverSession, forceSessionExpiry } from '../utils/session'
+
+vi.mock('../utils/session', () => ({
+	recoverSession: vi.fn(),
+	forceSessionExpiry: vi.fn(),
+	deleteSession: vi.fn()
+}))
+
+const A_QUERY = gql`
+	query GetSomething {
+		something
+	}
+`
+
+/**
+ * Run an operation through the link under test and resolve once it settles,
+ * reporting whatever reached the subscriber.
+ */
+const runThrough = (linkUnderTest, terminatingLink, context = {}) => {
+	return new Promise((resolve) => {
+		const results = []
+
+		execute(ApolloLink.from([linkUnderTest, terminatingLink]), { query: A_QUERY, context }).subscribe({
+			next: (result) => results.push(result),
+			error: (networkError) => resolve({ results, networkError }),
+			complete: () => resolve({ results, networkError: null })
+		})
+	})
+}
+
+const respondWith = (result) => new ApolloLink(() => Observable.of(result))
+
+const failWith = (networkError) => new ApolloLink(() => new Observable((observer) => observer.error(networkError)))
+
+describe('apollo links', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	describe('authMiddleware', () => {
+		const captureHeaders = () => {
+			const captured = {}
+			const link = new ApolloLink((operation) => {
+				captured.headers = operation.getContext().headers
+				return Observable.of({ data: {} })
+			})
+
+			return { link, captured }
+		}
+
+		it('sends the stored token as a bearer credential', async () => {
+			recoverSession.mockReturnValue('a-jwt')
+			const { link, captured } = captureHeaders()
+
+			await runThrough(authMiddleware, link)
+
+			expect(captured.headers.authorization).toBe('Bearer a-jwt')
+		})
+
+		it('sends an empty credential when there is no session', async () => {
+			recoverSession.mockReturnValue(null)
+			const { link, captured } = captureHeaders()
+
+			await runThrough(authMiddleware, link)
+
+			expect(captured.headers.authorization).toBe('')
+		})
+
+		it('keeps headers that were already in the context', async () => {
+			recoverSession.mockReturnValue('a-jwt')
+			const { link, captured } = captureHeaders()
+
+			await runThrough(authMiddleware, link, { headers: { 'accept-language': 'ca' } })
+
+			expect(captured.headers['accept-language']).toBe('ca')
+		})
+	})
+
+	describe('errorLink', () => {
+		const graphQLErrorWith = (code) => respondWith({ errors: [{ message: 'Original message', extensions: { code } }] })
+
+		it('expires the session when the backend rejects the credentials', async () => {
+			await runThrough(errorLink, graphQLErrorWith('UNAUTHENTICATED'))
+
+			expect(forceSessionExpiry).toHaveBeenCalled()
+		})
+
+		it('expires the session when the backend forbids the operation', async () => {
+			await runThrough(errorLink, graphQLErrorWith('FORBIDDEN'))
+
+			expect(forceSessionExpiry).toHaveBeenCalled()
+		})
+
+		it('hides the details of a server error behind a generic message', async () => {
+			const { results } = await runThrough(errorLink, graphQLErrorWith('INTERNAL_SERVER_ERROR'))
+
+			expect(results[0].errors[0].message).toBe('An error has occurred')
+		})
+
+		it('keeps the user signed in when the server fails', async () => {
+			await runThrough(errorLink, graphQLErrorWith('INTERNAL_SERVER_ERROR'))
+
+			expect(forceSessionExpiry).not.toHaveBeenCalled()
+		})
+
+		it('leaves any other error untouched', async () => {
+			const { results } = await runThrough(errorLink, graphQLErrorWith('BAD_USER_INPUT'))
+
+			expect(results[0].errors[0].message).toBe('Original message')
+			expect(forceSessionExpiry).not.toHaveBeenCalled()
+		})
+
+		it('expires the session when the transport reports an invalid token', async () => {
+			await runThrough(errorLink, failWith(Object.assign(new Error('Failed to fetch'), { response: 'invalid_token' })))
+
+			expect(forceSessionExpiry).toHaveBeenCalled()
+		})
+
+		it('keeps the user signed in when the network simply fails', async () => {
+			await runThrough(errorLink, failWith(new Error('Failed to fetch')))
+
+			expect(forceSessionExpiry).not.toHaveBeenCalled()
+		})
+	})
+})

--- a/src/apollo/config.test.js
+++ b/src/apollo/config.test.js
@@ -113,6 +113,13 @@ describe('apollo links', () => {
 			expect(forceSessionExpiry).not.toHaveBeenCalled()
 		})
 
+		it('survives an error that carries no extensions', async () => {
+			const { results } = await runThrough(errorLink, respondWith({ errors: [{ message: 'Original message' }] }))
+
+			expect(results[0].errors[0].message).toBe('Original message')
+			expect(forceSessionExpiry).not.toHaveBeenCalled()
+		})
+
 		it('expires the session when the transport reports an invalid token', async () => {
 			await runThrough(errorLink, failWith(Object.assign(new Error('Failed to fetch'), { response: 'invalid_token' })))
 

--- a/src/components/ButtonDelete/index.test.js
+++ b/src/components/ButtonDelete/index.test.js
@@ -1,0 +1,90 @@
+import { render, screen, within, waitForElementToBeRemoved } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { ButtonDelete } from './index'
+
+const renderButtonDelete = ({ deleteMutation = vi.fn().mockResolvedValue({}), onDelete = vi.fn() } = {}) => {
+	const user = userEvent.setup()
+
+	render(<ButtonDelete uuid='abc-123' deleteMutation={deleteMutation} onDelete={onDelete} />)
+
+	return { user, deleteMutation, onDelete }
+}
+
+const openTheConfirmation = async (user) => {
+	await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+	return screen.findByRole('dialog')
+}
+
+describe('ButtonDelete', () => {
+	it('asks for confirmation instead of deleting straight away', async () => {
+		const { user, deleteMutation } = renderButtonDelete()
+
+		const dialog = await openTheConfirmation(user)
+
+		expect(within(dialog).getByText('Are you sure?')).toBeVisible()
+		expect(deleteMutation).not.toHaveBeenCalled()
+	})
+
+	it('deletes nothing when the user backs out', async () => {
+		const { user, deleteMutation, onDelete } = renderButtonDelete()
+		const dialog = await openTheConfirmation(user)
+
+		await user.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+
+		await waitForElementToBeRemoved(() => screen.queryByRole('dialog'))
+		expect(deleteMutation).not.toHaveBeenCalled()
+		expect(onDelete).not.toHaveBeenCalled()
+	})
+
+	it('deletes the registry the button was given', async () => {
+		const { user, deleteMutation } = renderButtonDelete()
+		const dialog = await openTheConfirmation(user)
+
+		await user.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+		expect(deleteMutation).toHaveBeenCalledWith({ variables: { uuid: 'abc-123' } })
+	})
+
+	it('tells the caller once the registry is gone', async () => {
+		const { user, onDelete } = renderButtonDelete()
+		const dialog = await openTheConfirmation(user)
+
+		await user.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+		expect(onDelete).toHaveBeenCalled()
+	})
+
+	it('explains why a failed deletion did not happen', async () => {
+		const deleteMutation = vi.fn().mockRejectedValue(new Error('The registry is already gone'))
+		const { user } = renderButtonDelete({ deleteMutation })
+		const dialog = await openTheConfirmation(user)
+
+		await user.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+		expect(await screen.findByRole('alert')).toHaveTextContent('The registry is already gone')
+	})
+
+	it('does not report a deletion that failed', async () => {
+		const deleteMutation = vi.fn().mockRejectedValue(new Error('The registry is already gone'))
+		const { user, onDelete } = renderButtonDelete({ deleteMutation })
+		const dialog = await openTheConfirmation(user)
+
+		await user.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+		await screen.findByRole('alert')
+		expect(onDelete).not.toHaveBeenCalled()
+	})
+
+	it('lets the user try again after a failed deletion', async () => {
+		const deleteMutation = vi.fn().mockRejectedValue(new Error('The registry is already gone'))
+		const { user } = renderButtonDelete({ deleteMutation })
+		const dialog = await openTheConfirmation(user)
+
+		await user.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+		await screen.findByRole('alert')
+		expect(within(dialog).getByRole('button', { name: 'Delete' })).toBeEnabled()
+	})
+})

--- a/src/utils/session.js
+++ b/src/utils/session.js
@@ -23,6 +23,16 @@ function deleteSession() {
 }
 
 /**
+ * Tear down an invalidated session and send the user back to the landing page.
+ * The redirect is a full page load on purpose: it drops the Apollo cache and
+ * every piece of React state left over from the expired session.
+ */
+function forceSessionExpiry() {
+	deleteSession()
+	window.location.href = '/'
+}
+
+/**
  * Serialize and save user data in Session Storage
  * @param {string|number|Array|Object} data - data to store
  */
@@ -64,6 +74,7 @@ export {
 	saveSession,
 	recoverSession,
 	deleteSession,
+	forceSessionExpiry,
 	storeUserDataOnSessionStorage,
 	recoverUserDataFromSessionStorage,
 	deleteUserDataFromSessionStorage

--- a/src/utils/session.test.js
+++ b/src/utils/session.test.js
@@ -1,0 +1,119 @@
+import {
+	saveSession,
+	recoverSession,
+	deleteSession,
+	forceSessionExpiry,
+	storeUserDataOnSessionStorage,
+	recoverUserDataFromSessionStorage,
+	deleteUserDataFromSessionStorage
+} from './session'
+
+describe('session', () => {
+	beforeEach(() => {
+		sessionStorage.clear()
+	})
+
+	describe('raw values', () => {
+		it('reads back a value that was stored', () => {
+			saveSession('token', 'a-jwt')
+
+			expect(recoverSession('token')).toBe('a-jwt')
+		})
+
+		it('returns null for a key that was never stored', () => {
+			expect(recoverSession('token')).toBeNull()
+		})
+
+		it('wipes every stored value', () => {
+			saveSession('token', 'a-jwt')
+			storeUserDataOnSessionStorage({ email: 'example@mail.com' })
+
+			deleteSession()
+
+			expect(recoverSession('token')).toBeNull()
+			expect(sessionStorage.getItem('userData')).toBeNull()
+		})
+	})
+
+	describe('user data', () => {
+		it('keeps booleans as booleans across a store and recover cycle', () => {
+			storeUserDataOnSessionStorage({ isAdmin: false, isActive: true })
+
+			const recovered = recoverUserDataFromSessionStorage()
+
+			expect(recovered.isAdmin).toBe(false)
+			expect(recovered.isActive).toBe(true)
+		})
+
+		it('grants admin only to a user stored as an admin', () => {
+			storeUserDataOnSessionStorage({ isAdmin: true })
+
+			expect(recoverUserDataFromSessionStorage().isAdmin).toBe(true)
+		})
+
+		it('keeps strings untouched', () => {
+			storeUserDataOnSessionStorage({ email: 'example@mail.com', uuid: 'abc-123' })
+
+			const recovered = recoverUserDataFromSessionStorage()
+
+			expect(recovered.email).toBe('example@mail.com')
+			expect(recovered.uuid).toBe('abc-123')
+		})
+
+		it('turns numbers into strings, so callers must not assume a number comes back', () => {
+			storeUserDataOnSessionStorage({ registrationDate: 1715776800000 })
+
+			expect(recoverUserDataFromSessionStorage().registrationDate).toBe('1715776800000')
+		})
+
+		it('returns an empty object when nothing was stored', () => {
+			expect(recoverUserDataFromSessionStorage()).toEqual({})
+		})
+
+		it('drops the user data without touching the token', () => {
+			saveSession('token', 'a-jwt')
+			storeUserDataOnSessionStorage({ email: 'example@mail.com' })
+
+			deleteUserDataFromSessionStorage()
+
+			expect(recoverUserDataFromSessionStorage()).toEqual({})
+			expect(recoverSession('token')).toBe('a-jwt')
+		})
+	})
+
+	describe('forceSessionExpiry', () => {
+		const originalLocation = window.location
+
+		beforeEach(() => {
+			Object.defineProperty(window, 'location', {
+				configurable: true,
+				writable: true,
+				value: { href: '/spending/list' }
+			})
+		})
+
+		afterEach(() => {
+			Object.defineProperty(window, 'location', {
+				configurable: true,
+				writable: true,
+				value: originalLocation
+			})
+		})
+
+		it('wipes the session', () => {
+			saveSession('token', 'a-jwt')
+			storeUserDataOnSessionStorage({ email: 'example@mail.com' })
+
+			forceSessionExpiry()
+
+			expect(recoverSession('token')).toBeNull()
+			expect(recoverUserDataFromSessionStorage()).toEqual({})
+		})
+
+		it('sends the user back to the landing page', () => {
+			forceSessionExpiry()
+
+			expect(window.location.href).toBe('/')
+		})
+	})
+})


### PR DESCRIPTION
## Why

An audit of the test suite found that the covered code was mostly presentational, while the modules that decide **permissions**, **session lifetime** and **destructive actions** had no tests at all. This PR covers the four most critical of those, and fixes one real bug found while writing them.

## What changed

**`refactor: give session expiry a name of its own`**
Clearing the session and redirecting to the landing page is a single session-level action, not an Apollo concern, and it was duplicated in both branches of the error link. It moves to `src/utils/session.js` as `forceSessionExpiry`. The two links are now exported by name so they can be exercised on their own. No behaviour change.

**`test: cover the session store and the apollo links`**
- `src/utils/session.js` — the replacer/reviver pair that `isAdmin` travels through. If a boolean ever comes back as the string `'false'` it is truthy, and the admin navigation shows up for everyone.
- `src/apollo/config.js` — both links driven through `ApolloLink.execute` with a mock terminating link: the bearer header with and without a session, the expiry rules, and the `INTERNAL_SERVER_ERROR` message rewrite. No `fetch` mocking and no `window.location` surgery.

**`fix: stop the error link crashing on an error with no extensions`**
`err.extensions.code` was read unguarded. A graphQL error without `extensions` threw a `TypeError` inside the error link, which swallowed the response — the caller received neither the result nor the failure. The test that exposes it ships in the same commit.

**`test: cover the auth context and the delete confirmation`**
- `src/AuthContext.js` — sign in, sign out, the session surviving a reload, and that a regular user is not granted admin rights on rehydration.
- `src/components/ButtonDelete/index.js` — the only route to a destructive action in the app: nothing is deleted before the user confirms, backing out deletes nothing, and a failed deletion explains itself and can be retried.

## Notes for the reviewer

The new tests were mutation-checked rather than just run: removing the `'true'` branch from the session reviver fails 2 tests, and wiring the delete button to skip its modal fails 5.

Two characterization tests pin behaviour that is worth a second look but is **not** changed here: the session replacer turns numbers into strings, so `registrationDate` is a number right after login and a string after a reload. `AveragePerMonth` does `new Date(userData.registrationDate)`, which would be an *Invalid Date* if the backend issues that claim as an epoch number. Confirming the JWT format is a separate task.

341 → 378 tests, lint clean.