### PR TITLE
Test hygiene, and announce the empty suggestions state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,8 @@ Mutations typically use `useMutation` hook with error/success handling.
 - Test files colocated with components/modules (`.test.js` suffix)
 - Uses React Testing Library (component testing, NOT enzyme)
 - Tests typically verify rendering and user interactions
+- `vitest.setup.js` already loads the `@testing-library/jest-dom` matchers. Never import `@testing-library/jest-dom/extend-expect` in a test file
+- Query through `screen`, never through the object destructured from `render()`. Only `rerender` comes from that object
 - There is a [react-testing-library skill](.agents/skills/react-testing-library/SKILL.md) with 43 rules (query selection, async handling, anti-patterns, etc.). Reference it when writing or reviewing tests.
 
 Run tests:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,10 @@ Requires Node 24.14 (see `.nvmrc`). Copy `_env` to `.env` and set `VITE_PROTOCOL
 ## Testing notes
 
 - Test files are colocated with the `.test.js` suffix; environment is `jsdom` with globals enabled and `TZ=Europe/Madrid` (set in `vite.config.js`) — relevant for date-sensitive tests.
-- Setup file `vitest.setup.js` pulls in `@testing-library/jest-dom` matchers.
+- Setup file `vitest.setup.js` pulls in `@testing-library/jest-dom` matchers. Never import
+  `@testing-library/jest-dom/extend-expect` in a test file — it is already loaded.
+- Query through `screen`, never through the object destructured from `render()`. Only `rerender` comes
+  from that object.
 
 ## Files to change with care
 

--- a/src/components/DidibudgetLogo/index.test.js
+++ b/src/components/DidibudgetLogo/index.test.js
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
 
 
 import { DidibudgetLogo } from './'

--- a/src/components/EmojiGreenCheck/index.test.js
+++ b/src/components/EmojiGreenCheck/index.test.js
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
 
 import { EmojiGreenCheck } from './index'
 

--- a/src/components/EmojiMagnifyingGlass/index.test.js
+++ b/src/components/EmojiMagnifyingGlass/index.test.js
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
 
 import { EmojiMagnifyingGlass } from './index'
 

--- a/src/components/EmojiRedCross/index.test.js
+++ b/src/components/EmojiRedCross/index.test.js
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
 
 import { EmojiRedCross } from './index'
 

--- a/src/components/ErrorAlert/index.test.js
+++ b/src/components/ErrorAlert/index.test.js
@@ -1,13 +1,12 @@
-import { render } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
 
 import { ErrorAlert } from './'
 
 describe('ErrorAlert', () => {
 	it('renders correctly', () => {
-		const { getByRole, getByText } = render(<ErrorAlert errorMessage='foo' />)
+		render(<ErrorAlert errorMessage='foo' />)
 
-		expect(getByRole('alert')).toBeVisible()
-		expect(getByText('foo')).toBeVisible()
+		expect(screen.getByRole('alert')).toBeVisible()
+		expect(screen.getByText('foo')).toBeVisible()
 	})
 })

--- a/src/components/Expenses/AveragePerMonth/index.test.js
+++ b/src/components/Expenses/AveragePerMonth/index.test.js
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 
 import { AuthContext } from '../../../AuthContext'

--- a/src/components/Expenses/RecurringExpenseSuggestionsOverview/index.js
+++ b/src/components/Expenses/RecurringExpenseSuggestionsOverview/index.js
@@ -13,7 +13,7 @@ export const RecurringExpenseSuggestionsOverview = ({ suggestions }) => {
 				</div>
 				<div className="card-body pb-0">
 					{!hasSuggestions ? (
-						<p className="text-light">No suggestions available right now.</p>
+						<p className="text-light" role="status">No suggestions available right now.</p>
 					) : (
 						<div className="row">
 							{

--- a/src/components/Expenses/RecurringExpenseSuggestionsOverview/index.test.js
+++ b/src/components/Expenses/RecurringExpenseSuggestionsOverview/index.test.js
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+
+import { RecurringExpenseSuggestionsOverview } from './'
+
+describe('RecurringExpenseSuggestionsOverview', () => {
+	it('announces politely that there is nothing to suggest', () => {
+		render(<RecurringExpenseSuggestionsOverview suggestions={[]} />)
+
+		expect(screen.getByRole('status')).toHaveTextContent('No suggestions available right now.')
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+	})
+})

--- a/src/components/Footer/index.test.js
+++ b/src/components/Footer/index.test.js
@@ -1,17 +1,16 @@
 import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
 
 import { Footer } from './'
 
 describe('Footer', () => {
 	it('renders a link with correct attributes', () => {
-		const { getByText } = render(<Footer />)
+		render(<Footer />)
 
-		expect(getByText('didaquis').href).toBe('https://didaquis.github.io/')
-		expect(getByText('didaquis').closest('a')).toHaveAttribute('href', 'https://didaquis.github.io/') /* Alternative way */
+		expect(screen.getByText('didaquis').href).toBe('https://didaquis.github.io/')
+		expect(screen.getByText('didaquis').closest('a')).toHaveAttribute('href', 'https://didaquis.github.io/') /* Alternative way */
 
-		expect(getByText('didaquis').target).toBe('_blank')
-		expect(getByText('didaquis').rel).toBe('noreferrer noopener')
+		expect(screen.getByText('didaquis').target).toBe('_blank')
+		expect(screen.getByText('didaquis').rel).toBe('noreferrer noopener')
 	})
 
 	it('contains an expected text', () => {

--- a/src/components/InformativeBadge/index.test.js
+++ b/src/components/InformativeBadge/index.test.js
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
 
 import { InformativeBadge } from './index'
 

--- a/src/components/Jumbotron/index.test.js
+++ b/src/components/Jumbotron/index.test.js
@@ -1,22 +1,21 @@
 import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
 
 import { Jumbotron } from './'
 
 describe('Jumbotron', () => {
 	it('contains an expected text', () => {
-		const { getByText } = render(<Jumbotron title='foo' subtitle='bar' />)
+		render(<Jumbotron title='foo' subtitle='bar' />)
 
-		expect(getByText('foo')).toBeVisible()
-		expect(getByText('bar')).toBeVisible()
+		expect(screen.getByText('foo')).toBeVisible()
+		expect(screen.getByText('bar')).toBeVisible()
 	})
 
 	it('contains an expected text, included more content as subtitle', () => {
-		const { getByText } = render(<Jumbotron title='foo' subtitle='bar' subtitleExtraLine='biz' />)
+		render(<Jumbotron title='foo' subtitle='bar' subtitleExtraLine='biz' />)
 
-		expect(getByText('foo')).toBeVisible()
-		expect(getByText('bar')).toBeVisible()
-		expect(getByText('biz')).toBeVisible()
+		expect(screen.getByText('foo')).toBeVisible()
+		expect(screen.getByText('bar')).toBeVisible()
+		expect(screen.getByText('biz')).toBeVisible()
 	})
 
 	it('contains the correct DOM nodes', () => {

--- a/src/components/LoginForm/index.test.js
+++ b/src/components/LoginForm/index.test.js
@@ -1,6 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import '@testing-library/jest-dom/extend-expect'
 import { MockedProvider } from '@apollo/client/testing'
 import { InMemoryCache } from '@apollo/client'
 

--- a/src/components/PageSubTitle/index.test.js
+++ b/src/components/PageSubTitle/index.test.js
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
 
 import { PageSubTitle } from './'
 

--- a/src/components/PageTitle/index.test.js
+++ b/src/components/PageTitle/index.test.js
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
 
 import { PageTitle } from './'
 

--- a/src/components/SavingsAndInvestments/ViewGetSavingsAndInvestments/index.test.js
+++ b/src/components/SavingsAndInvestments/ViewGetSavingsAndInvestments/index.test.js
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
 import { CategoryType } from '../utils/index'
 
 import { ViewGetSavingsAndInvestments } from './'

--- a/src/components/SectionTitle/index.test.js
+++ b/src/components/SectionTitle/index.test.js
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
 
 import { SectionTitle } from './'
 

--- a/src/components/SubmitButton/index.test.js
+++ b/src/components/SubmitButton/index.test.js
@@ -1,37 +1,36 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import '@testing-library/jest-dom/extend-expect'
 
 import { SubmitButton } from './'
 
 describe('SubmitButton', () => {
 	it('renders correctly', () => {
 		const handleClick = () => { }
-		const { getByRole } = render(<SubmitButton disabled={false} onClick={handleClick}>Submit</SubmitButton>)
+		render(<SubmitButton disabled={false} onClick={handleClick}>Submit</SubmitButton>)
 
-		expect(getByRole('button', { name: /^Submit$/i })).toBeVisible()
+		expect(screen.getByRole('button', { name: /^Submit$/i })).toBeVisible()
 	})
 
 	it('renders a button disabled or not depending of the props', () => {
 		const handleClick = () => { }
-		const { getByRole, rerender } = render(<SubmitButton disabled={true} onClick={handleClick}>Submit</SubmitButton>)
+		const { rerender } = render(<SubmitButton disabled={true} onClick={handleClick}>Submit</SubmitButton>)
 
-		expect(getByRole('button', { name: /^Submit$/i })).toBeDisabled()
+		expect(screen.getByRole('button', { name: /^Submit$/i })).toBeDisabled()
 
 		rerender(<SubmitButton disabled={false} onClick={handleClick}>Submit</SubmitButton>)
 
-		expect(getByRole('button', { name: /^Submit$/i })).not.toBeDisabled()
+		expect(screen.getByRole('button', { name: /^Submit$/i })).not.toBeDisabled()
 	})
 
 	it('captures clicks', async () => {
 		const user = userEvent.setup()
 		const handleClick = vi.fn()
 
-		const { getByRole } = render(
+		render(
 			<SubmitButton onClick={handleClick}>Submit</SubmitButton>
 		)
 
-		const node = getByRole('button', { name: /^Submit$/i })
+		const node = screen.getByRole('button', { name: /^Submit$/i })
 
 		expect(handleClick).not.toHaveBeenCalled()
 		await user.click(node)

--- a/src/components/SubmitButtonHelper/index.test.js
+++ b/src/components/SubmitButtonHelper/index.test.js
@@ -1,18 +1,17 @@
-import { render } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
 
 import { SubmitButtonHelper } from './'
 
 describe('SubmitButtonHelper', () => {
 	it('renders helper text if receive true by props', () => {
-		const { getByText } = render(<SubmitButtonHelper mustShowHelper={true} />)
+		render(<SubmitButtonHelper mustShowHelper={true} />)
 
-		expect(getByText('Form submission is only enabled with valid data')).toBeVisible()
+		expect(screen.getByText('Form submission is only enabled with valid data')).toBeVisible()
 	})
 
 	it('should not render helper text if receive false by props', () => {
-		const { getByText } = render(<SubmitButtonHelper mustShowHelper={false} />)
+		render(<SubmitButtonHelper mustShowHelper={false} />)
 
-		expect(getByText('Form submission is only enabled with valid data')).toHaveClass('invisible')
+		expect(screen.getByText('Form submission is only enabled with valid data')).toHaveClass('invisible')
 	})
 })

--- a/src/components/UserCard/index.test.js
+++ b/src/components/UserCard/index.test.js
@@ -1,5 +1,4 @@
-import { render } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
 
 import { UserCard } from './'
 
@@ -9,9 +8,9 @@ describe('UserCard', () => {
 			email: 'foo@mail.com',
 			isAdmin: false
 		}
-		const { getByText } = render(<UserCard userData={data} />)
+		render(<UserCard userData={data} />)
 
-		expect(getByText('foo@mail.com')).toBeVisible()
+		expect(screen.getByText('foo@mail.com')).toBeVisible()
 	})
 
 	it('should show if user is an administrator user', () => {
@@ -19,15 +18,15 @@ describe('UserCard', () => {
 			email: 'foo@mail.com',
 			isAdmin: false
 		}
-		const { queryByText, rerender } = render(<UserCard userData={props} />)
+		const { rerender } = render(<UserCard userData={props} />)
 
-		expect(queryByText('You are an administrator user!')).not.toBeInTheDocument()
+		expect(screen.queryByText('You are an administrator user!')).not.toBeInTheDocument()
 
 		const newProps = {
 			email: 'foo@mail.com',
 			isAdmin: true
 		}
 		rerender(<UserCard userData={newProps} />)
-		expect(queryByText('You are an administrator user!')).toBeVisible()
+		expect(screen.queryByText('You are an administrator user!')).toBeVisible()
 	})
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,5 @@
 import { defineConfig, transformWithOxc } from 'vite'
+import { configDefaults } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 // Vite 8 bundles with Rolldown/Oxc, which infers the loader from the file
@@ -50,6 +51,9 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: './vitest.setup.js',
+    // Agent worktrees live inside the repo under `.claude/worktrees/`. Without this
+    // exclusion their test files run as part of this project's suite.
+    exclude: [...configDefaults.exclude, '**/.claude/**'],
     env: {
       TZ: 'Europe/Madrid',
     },


### PR DESCRIPTION
Follow-ups to #236, agreed after reviewing that branch in the browser.

## Announce the empty suggestions state

`RecurringExpenseSuggestionsOverview` renders "No suggestions available right now." when the day has no recurring expenses due. It is styled as plain text inside its card, and that stays: it is a card-scoped empty state, not a screen-scoped one, so the full-width `alert-info` block used elsewhere would be too heavy here and would fight the card's own `border-info`.

What it was missing is the other half of what `EmptyState` provides: a live region. It now carries `role="status"`, so a screen reader is told the card came back empty instead of being left silent. New test covers it — confirmed failing against the code without the attribute before committing.

## Test hygiene

- Dropped `import '@testing-library/jest-dom/extend-expect'` from 17 test files. `vitest.setup.js` already loads the matchers, so those imports were redundant. Nothing was broken — the repo is on jest-dom 5.17, where that entry point still exists.
- Converted the 6 test files that destructured queries out of `render()` to query through `screen`. `rerender` still comes from the returned object, which is correct.
- Both conventions are now written down in `CLAUDE.md` and `AGENTS.md`, so this does not drift back.

## Keep agent worktrees out of the test suite

`vite.config.js` declared no `exclude`, so vitest globbed the whole project — including the agent worktrees that live inside the repo at `.claude/worktrees/`. `npm run test` was running 147 test files instead of 49 and taking 40s instead of 11s, and a failure in another branch's worktree would fail this project's suite and its pre-commit hooks.

Now `exclude: [...configDefaults.exclude, '**/.claude/**']`, keeping vitest's own defaults rather than replacing them.

## Verification

Suite 381/381, lint clean, build OK. The dashboard could not be checked in the browser for the empty branch — there are real suggestions today, so that branch does not render — which is why it got a unit test instead.