### PR TITLE
Confirm a saved expense with a floating toast

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ The page is dark but form controls are **not**: the app uses default Bootstrap `
 
 `ErrorAlert` (red, `role="alert"`) is only for failures: network, GraphQL, form validation. For "no data
 yet" or "no results" use `EmptyState` (`role="status"`). Never use `ErrorAlert` for an empty list.
+For a confirmation after a successful write use `SuccessToast` (`role="status"`, auto-hides): pass it a
+`{ id, message }` object with a fresh `id` per save, never a bare string.
 
 ## Commands
 

--- a/src/components/Expenses/AddExpenseForm/index.js
+++ b/src/components/Expenses/AddExpenseForm/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { useMutation } from '@apollo/client'
 
 import { ErrorAlert } from '../../ErrorAlert'
+import { SuccessToast } from '../../SuccessToast'
 import { SubmitButton } from '../../SubmitButton'
 import { SubmitButtonHelper } from '../../SubmitButtonHelper'
 import { DateQuickSelector } from '../../DateQuickSelector'
@@ -18,7 +19,8 @@ const startOfToday = () => startOfDay(new Date())
 export const AddExpenseForm = ({ categories, frequentCategories }) => {
 	const [isDisabled, setIsDisabled] = useState(false)
 	const [error, setError] = useState(null)
-	const [savedMessage, setSavedMessage] = useState(null)
+	const [notice, setNotice] = useState(null)
+	const noticeIdRef = useRef(0)
 	const [amount, setAmount] = useState('')
 	const [date, setDate] = useState(startOfToday)
 	const [selected, setSelected] = useState(null)
@@ -29,10 +31,10 @@ export const AddExpenseForm = ({ categories, frequentCategories }) => {
 	const isValid = validateAddExpenseForm(amount, date, selected)
 
 	useEffect(() => {
-		if (savedMessage) {
+		if (notice) {
 			amountInputRef.current?.focus()
 		}
-	}, [savedMessage])
+	}, [notice])
 
 	const handleSubmit = (event) => {
 		event.preventDefault()
@@ -41,7 +43,7 @@ export const AddExpenseForm = ({ categories, frequentCategories }) => {
 		}
 		setIsDisabled(true)
 		setError(null)
-		setSavedMessage(null)
+		setNotice(null)
 
 		const quantity = parseFloat(amount)
 		const label = selected.label
@@ -54,7 +56,8 @@ export const AddExpenseForm = ({ categories, frequentCategories }) => {
 		}
 
 		registerExpense({ variables }).then(() => {
-			setSavedMessage(`Saved: ${quantity.toFixed(2)} EUR · ${label}`)
+			noticeIdRef.current += 1
+			setNotice({ id: noticeIdRef.current, message: `${quantity.toFixed(2)} EUR · ${label}` })
 			setAmount('')
 			setDate(startOfToday())
 			setSelected(null)
@@ -70,12 +73,11 @@ export const AddExpenseForm = ({ categories, frequentCategories }) => {
 			<div className="row justify-content-center">
 				<form className="col-md-8" onSubmit={handleSubmit}>
 
+					<SuccessToast notice={notice} />
+
 					{
-						// Feedback sits above every field on purpose: saving reopens the category picker,
+						// The error sits above every field on purpose: saving reopens the category picker,
 						// so anything below it gets pushed off a 390px screen.
-					}
-					{
-						savedMessage && <p className="alert alert-success py-3 text-center mb-4" role="status">{savedMessage}</p>
 					}
 					{
 						error && <ErrorAlert errorMessage={error} />

--- a/src/components/Expenses/AddExpenseForm/index.test.js
+++ b/src/components/Expenses/AddExpenseForm/index.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MockedProvider } from '@apollo/client/testing'
 
@@ -89,7 +89,7 @@ describe('AddExpenseForm', () => {
 		await user.click(screen.getAllByRole('button', { name: /Taxes/ })[0])
 		await user.click(screen.getByRole('button', { name: 'Save expense' }))
 
-		expect(await screen.findByRole('status')).toHaveTextContent('Saved: 12.40 EUR · Taxes')
+		await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent(/^✓ 12\.40 EUR · Taxes$/))
 	})
 
 	it('clears the amount and the category after saving', async () => {
@@ -100,7 +100,7 @@ describe('AddExpenseForm', () => {
 		await user.click(screen.getAllByRole('button', { name: /Taxes/ })[0])
 		await user.click(screen.getByRole('button', { name: 'Save expense' }))
 
-		await screen.findByRole('status')
+		await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('12.40 EUR · Taxes'))
 
 		expect(screen.getByLabelText(/Amount/)).toHaveValue(null)
 		expect(screen.getByLabelText('Filter categories')).toBeVisible()
@@ -156,7 +156,7 @@ describe('AddExpenseForm', () => {
 		await user.click(screen.getAllByRole('button', { name: /Taxes/ })[0])
 		await user.click(screen.getByRole('button', { name: 'Save expense' }))
 
-		await screen.findByRole('status')
+		await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('12.40 EUR · Taxes'))
 
 		expect(screen.getByRole('button', { name: 'Today', pressed: true })).toBeVisible()
 	})

--- a/src/components/SuccessToast/index.js
+++ b/src/components/SuccessToast/index.js
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
+
+import './styles.css'
+
+const AUTO_HIDE_DELAY = 4000
+/* Tiene que coincidir con la duración de las animaciones de styles.css */
+const LEAVE_DURATION = 150
+
+export const SuccessToast = ({ notice }) => {
+	const [isVisible, setIsVisible] = useState(false)
+	const [isLeaving, setIsLeaving] = useState(false)
+
+	useEffect(() => {
+		if (!notice) {
+			return
+		}
+
+		setIsLeaving(false)
+		setIsVisible(true)
+
+		const leaveTimer = setTimeout(() => setIsLeaving(true), AUTO_HIDE_DELAY)
+		const hideTimer = setTimeout(() => setIsVisible(false), AUTO_HIDE_DELAY + LEAVE_DURATION)
+
+		return () => {
+			clearTimeout(leaveTimer)
+			clearTimeout(hideTimer)
+		}
+	}, [notice])
+
+	const toastClassName = isLeaving ? 'toast show success-toast success-toast--leaving' : 'toast show success-toast'
+
+	return (
+		<div className="toast-container position-fixed top-0 start-50 translate-middle-x p-3" role="status" aria-live="polite" aria-atomic="true">
+			{
+				// La región viva se queda montada siempre: un lector de pantalla sólo anuncia
+				// cambios dentro de una región que ya existía en el DOM.
+				// La `key` fuerza el reemplazo del nodo, para que dos mensajes idénticos
+				// seguidos se vuelvan a anunciar y se rebobine la animación de entrada.
+			}
+			{
+				isVisible && notice && (
+					<div className={toastClassName} key={notice.id}>
+						<div className="toast-body text-center">
+							<span aria-hidden="true">✓ </span>{notice.message}
+						</div>
+					</div>
+				)
+			}
+		</div>
+	)
+}
+
+SuccessToast.propTypes = {
+	notice: PropTypes.shape({
+		id: PropTypes.number.isRequired,
+		message: PropTypes.string.isRequired
+	})
+}

--- a/src/components/SuccessToast/index.js
+++ b/src/components/SuccessToast/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import './styles.css'
 
 const AUTO_HIDE_DELAY = 4000
-/* Tiene que coincidir con la duración de las animaciones de styles.css */
+/* Must match the animation duration in styles.css */
 const LEAVE_DURATION = 150
 
 export const SuccessToast = ({ notice }) => {
@@ -37,10 +37,10 @@ export const SuccessToast = ({ notice }) => {
 	return (
 		<div className="toast-container success-toast-container position-fixed start-50 translate-middle-x p-3" role="status" aria-live="polite" aria-atomic="true">
 			{
-				// La región viva se queda montada siempre: un lector de pantalla sólo anuncia
-				// cambios dentro de una región que ya existía en el DOM.
-				// La `key` fuerza el reemplazo del nodo, para que dos mensajes idénticos
-				// seguidos se vuelvan a anunciar y se rebobine la animación de entrada.
+				// The live region stays mounted at all times: a screen reader only announces
+				// changes inside a region that already existed in the DOM.
+				// The `key` forces the node to be replaced, so two identical consecutive
+				// messages get announced again and the entry animation rewinds.
 			}
 			{
 				isVisible && notice && (

--- a/src/components/SuccessToast/index.js
+++ b/src/components/SuccessToast/index.js
@@ -35,7 +35,7 @@ export const SuccessToast = ({ notice }) => {
 	const toastClassName = isLeaving ? 'toast show success-toast success-toast--leaving' : 'toast show success-toast'
 
 	return (
-		<div className="toast-container success-toast-container position-fixed top-0 start-50 translate-middle-x p-3" role="status" aria-live="polite" aria-atomic="true">
+		<div className="toast-container success-toast-container position-fixed start-50 translate-middle-x p-3" role="status" aria-live="polite" aria-atomic="true">
 			{
 				// La región viva se queda montada siempre: un lector de pantalla sólo anuncia
 				// cambios dentro de una región que ya existía en el DOM.

--- a/src/components/SuccessToast/index.js
+++ b/src/components/SuccessToast/index.js
@@ -11,8 +11,12 @@ export const SuccessToast = ({ notice }) => {
 	const [isVisible, setIsVisible] = useState(false)
 	const [isLeaving, setIsLeaving] = useState(false)
 
+	/* The id, not the object, is the identity: a caller passing an inline object
+	   would otherwise restart the timers on every parent render */
+	const noticeId = notice?.id
+
 	useEffect(() => {
-		if (!notice) {
+		if (noticeId === undefined) {
 			return
 		}
 
@@ -26,7 +30,7 @@ export const SuccessToast = ({ notice }) => {
 			clearTimeout(leaveTimer)
 			clearTimeout(hideTimer)
 		}
-	}, [notice?.id])
+	}, [noticeId])
 
 	const toastClassName = isLeaving ? 'toast show success-toast success-toast--leaving' : 'toast show success-toast'
 

--- a/src/components/SuccessToast/index.js
+++ b/src/components/SuccessToast/index.js
@@ -26,12 +26,12 @@ export const SuccessToast = ({ notice }) => {
 			clearTimeout(leaveTimer)
 			clearTimeout(hideTimer)
 		}
-	}, [notice])
+	}, [notice?.id])
 
 	const toastClassName = isLeaving ? 'toast show success-toast success-toast--leaving' : 'toast show success-toast'
 
 	return (
-		<div className="toast-container position-fixed top-0 start-50 translate-middle-x p-3" role="status" aria-live="polite" aria-atomic="true">
+		<div className="toast-container success-toast-container position-fixed top-0 start-50 translate-middle-x p-3" role="status" aria-live="polite" aria-atomic="true">
 			{
 				// La región viva se queda montada siempre: un lector de pantalla sólo anuncia
 				// cambios dentro de una región que ya existía en el DOM.

--- a/src/components/SuccessToast/index.test.js
+++ b/src/components/SuccessToast/index.test.js
@@ -66,4 +66,34 @@ describe('SuccessToast', () => {
 
 		expect(screen.getByRole('status')).toHaveTextContent('12.40 EUR · Taxes')
 	})
+
+	it('re-announces an identical message that arrives while the previous one is still visible', () => {
+		vi.useFakeTimers()
+
+		const { rerender } = render(<SuccessToast notice={{ id: 1, message: '12.40 EUR · Taxes' }} />)
+
+		act(() => {
+			vi.advanceTimersByTime(2000)
+		})
+
+		const firstNode = screen.getByRole('status').firstChild
+
+		rerender(<SuccessToast notice={{ id: 2, message: '12.40 EUR · Taxes' }} />)
+
+		// jsdom offers no other observable for "the node was replaced" than identity,
+		// so we assert on it directly even though it is an implementation detail.
+		expect(screen.getByRole('status').firstChild).not.toBe(firstNode)
+
+		act(() => {
+			vi.advanceTimersByTime(2500)
+		})
+
+		expect(screen.getByRole('status')).toHaveTextContent('12.40 EUR · Taxes')
+	})
+
+	it('hides the decorative check mark from assistive technology', () => {
+		render(<SuccessToast notice={{ id: 1, message: '12.40 EUR · Taxes' }} />)
+
+		expect(screen.getByRole('status').querySelector('span[aria-hidden="true"]')).toBeInTheDocument()
+	})
 })

--- a/src/components/SuccessToast/index.test.js
+++ b/src/components/SuccessToast/index.test.js
@@ -1,0 +1,69 @@
+import { act, render, screen } from '@testing-library/react'
+
+import { SuccessToast } from './index'
+
+describe('SuccessToast', () => {
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it('keeps the live region mounted when there is nothing to announce', () => {
+		render(<SuccessToast notice={null} />)
+
+		expect(screen.getByRole('status')).toBeEmptyDOMElement()
+	})
+
+	it('shows the message of the notice it receives', () => {
+		render(<SuccessToast notice={{ id: 1, message: '12.40 EUR · Taxes' }} />)
+
+		expect(screen.getByRole('status')).toHaveTextContent('12.40 EUR · Taxes')
+	})
+
+	it('keeps the message on screen while it fades out, and removes it afterwards', () => {
+		vi.useFakeTimers()
+
+		render(<SuccessToast notice={{ id: 1, message: '12.40 EUR · Taxes' }} />)
+
+		expect(screen.getByRole('status')).toHaveTextContent('12.40 EUR · Taxes')
+
+		act(() => {
+			vi.advanceTimersByTime(4000)
+		})
+
+		expect(screen.getByRole('status')).toHaveTextContent('12.40 EUR · Taxes')
+
+		act(() => {
+			vi.advanceTimersByTime(150)
+		})
+
+		expect(screen.getByRole('status')).toBeEmptyDOMElement()
+	})
+
+	it('marks the message as leaving before removing it', () => {
+		vi.useFakeTimers()
+
+		render(<SuccessToast notice={{ id: 1, message: '12.40 EUR · Taxes' }} />)
+
+		act(() => {
+			vi.advanceTimersByTime(4000)
+		})
+
+		expect(screen.getByRole('status').firstChild).toHaveClass('success-toast--leaving')
+	})
+
+	it('shows an identical message again when a new notice arrives after the previous one expired', () => {
+		vi.useFakeTimers()
+
+		const { rerender } = render(<SuccessToast notice={{ id: 1, message: '12.40 EUR · Taxes' }} />)
+
+		act(() => {
+			vi.advanceTimersByTime(4150)
+		})
+
+		expect(screen.getByRole('status')).toBeEmptyDOMElement()
+
+		rerender(<SuccessToast notice={{ id: 2, message: '12.40 EUR · Taxes' }} />)
+
+		expect(screen.getByRole('status')).toHaveTextContent('12.40 EUR · Taxes')
+	})
+})

--- a/src/components/SuccessToast/styles.css
+++ b/src/components/SuccessToast/styles.css
@@ -1,30 +1,38 @@
 /* La duración está duplicada en index.js (LEAVE_DURATION). Si cambias una, cambia la otra. */
 .success-toast {
-  animation: success-toast-in 150ms ease-out;
-  pointer-events: none;
+	animation: success-toast-in 150ms ease-out;
 }
 
+/* Bootstrap's toast is 85% opaque; over the dark page whatever sits behind it
+   bleeds through the text */
+.toast.success-toast {
+	background-color: #fff;
+}
+
+/* Clears the navbar so the toast never covers it. Bootstrap 5.1.3 gives
+   .toast-container no z-index of its own */
 .success-toast-container {
-  z-index: 1090;
+	top: 64px;
+	z-index: 1090;
 }
 
 .success-toast--leaving {
-  animation: success-toast-out 150ms ease-in forwards;
+	animation: success-toast-out 150ms ease-in forwards;
 }
 
 @keyframes success-toast-in {
-  from { opacity: 0; transform: translateY(-8px); }
-  to { opacity: 1; transform: none; }
+	from { opacity: 0; transform: translateY(-8px); }
+	to { opacity: 1; transform: none; }
 }
 
 @keyframes success-toast-out {
-  from { opacity: 1; transform: none; }
-  to { opacity: 0; transform: translateY(-8px); }
+	from { opacity: 1; transform: none; }
+	to { opacity: 0; transform: translateY(-8px); }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .success-toast,
-  .success-toast--leaving {
-    animation: none;
-  }
+	.success-toast,
+	.success-toast--leaving {
+		animation: none;
+	}
 }

--- a/src/components/SuccessToast/styles.css
+++ b/src/components/SuccessToast/styles.css
@@ -1,0 +1,25 @@
+/* La duración está duplicada en index.js (LEAVE_DURATION). Si cambias una, cambia la otra. */
+.success-toast {
+  animation: success-toast-in 150ms ease-out;
+}
+
+.success-toast--leaving {
+  animation: success-toast-out 150ms ease-in forwards;
+}
+
+@keyframes success-toast-in {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: none; }
+}
+
+@keyframes success-toast-out {
+  from { opacity: 1; transform: none; }
+  to { opacity: 0; transform: translateY(-8px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .success-toast,
+  .success-toast--leaving {
+    animation: none;
+  }
+}

--- a/src/components/SuccessToast/styles.css
+++ b/src/components/SuccessToast/styles.css
@@ -1,4 +1,4 @@
-/* La duración está duplicada en index.js (LEAVE_DURATION). Si cambias una, cambia la otra. */
+/* The duration is duplicated in index.js (LEAVE_DURATION). Change one, change the other. */
 .success-toast {
 	animation: success-toast-in 150ms ease-out;
 }

--- a/src/components/SuccessToast/styles.css
+++ b/src/components/SuccessToast/styles.css
@@ -1,6 +1,11 @@
 /* La duración está duplicada en index.js (LEAVE_DURATION). Si cambias una, cambia la otra. */
 .success-toast {
   animation: success-toast-in 150ms ease-out;
+  pointer-events: none;
+}
+
+.success-toast-container {
+  z-index: 1090;
 }
 
 .success-toast--leaving {


### PR DESCRIPTION
## What changed

Saving an expense in `/spending/add` used to be confirmed with a green `alert alert-success` block rendered above every form field. It is now a floating toast.

## Why

The old confirmation had three problems, in order of importance:

1. It was an alert-shaped block for a routine, expected operation.
2. It never went away. While you typed the next expense, the confirmation of the previous one was still on screen.
3. It pushed the whole form down when it appeared, so the screen jumped at the exact moment you were about to type the amount.

Adding expenses is a repetitive, one-after-another task on a phone. All three worked against that.

## How it works

New `SuccessToast` component (`src/components/SuccessToast/`), the success counterpart to `ErrorAlert` and `EmptyState`. Plain markup with Bootstrap classes plus a colocated `styles.css`, following the `Spinner` pattern. No new dependencies.

Two layers, and the split is required for accessibility:

- The outer container is **always mounted** and carries `role="status"` / `aria-live="polite"` / `aria-atomic="true"`. A screen reader only announces changes inside a live region that already existed in the DOM, so mounting and unmounting the region would lose the announcement.
- The inner node is keyed on `notice.id`. Saving two identical expenses in a row produces the same text, so without the key React would leave the DOM untouched and nothing would be announced. The key also rewinds the entry animation, which makes the repeat visible as well as audible.

`AddExpenseForm` therefore passes `{ id, message }` with a fresh id per save, not a bare string.

Animation is 150 ms in and out, with `prefers-reduced-motion` honoured. The duration is deliberately duplicated between `LEAVE_DURATION` in `index.js` and `styles.css`, with a cross-reference comment in each.

## Notes for the reviewer

- **`reactstrap`'s `Toast` is deliberately not used.** It hardcodes `role="alert"` after spreading props, so the role cannot be overridden. That would nest an alert inside our status region, announce success interruptively, and collide with the `findByRole('alert')` assertion in the existing error test.
- **The toast sits at `top: 64px`, not `top: 0`.** At 390px the navbar is not fixed, so a top-anchored toast covered the nav icons: it either swallowed taps for 4 seconds, or, with `pointer-events: none`, let taps fall through to whatever was behind — including Log out. Clearing the navbar removes the conflict instead of patching it. The background is forced opaque because Bootstrap's `rgba(255,255,255,.85)` let the icons bleed through the text.
- **`.toast-container` gets an explicit `z-index: 1090`.** Bootstrap only added one in 5.3; this project is on 5.1.3, where the toast would otherwise stack by DOM order alone and an open navbar dropdown would paint over it.
- **The effect depends on `noticeId`, not on the `notice` object.** Depending on the object would restart the timers on every parent render for any caller passing an inline object, and the toast would never auto-hide.
- Three existing tests in `AddExpenseForm/index.test.js` used `await screen.findByRole('status')` as a "the save finished" signal. That no longer works, because the region is now present from the first render and the wait would resolve instantly. They now wait on the region's text content.

## Verification

- 388 tests passing, lint clean.
- Checked in a real browser at 390px: no layout shift at all (the Amount field stays at 182.65px across every sample), both animations measured frame by frame, the node is genuinely replaced when two identical expenses are saved back to back, and no horizontal overflow.
- **Not verified:** `prefers-reduced-motion`. The CSS rule is present and parses, but confirming it needs the OS setting toggled.

## Out of scope

Reusing this toast in `/monthly-balance/add` is agreed but deliberately left for a separate PR: doing it properly needs a database migration and an endpoint contract change (one balance per user and month), which would make this PR unreviewable.
