### PR TITLE
feat: confirm monthly balance with a toast instead of redirecting

### DIFF
--- a/src/components/MonthlyBalance/RegisterMonthlyBalanceForm/index.js
+++ b/src/components/MonthlyBalance/RegisterMonthlyBalanceForm/index.js
@@ -41,6 +41,9 @@ export const RegisterMonthlyBalanceForm = () => {
 
 	const handleSubmit = (event) => {
 		event.preventDefault()
+		if (!isValid) {
+			return
+		}
 		setIsDisabled(true)
 		setError(null)
 		setNotice(null)

--- a/src/components/MonthlyBalance/RegisterMonthlyBalanceForm/index.js
+++ b/src/components/MonthlyBalance/RegisterMonthlyBalanceForm/index.js
@@ -1,8 +1,8 @@
-import { useState, Fragment } from 'react'
+import { useEffect, useRef, useState, Fragment } from 'react'
 import { useMutation } from '@apollo/client'
-import { useNavigate } from 'react-router'
 
 import { ErrorAlert } from '../../ErrorAlert'
+import { SuccessToast } from '../../SuccessToast'
 import { SubmitButton } from '../../SubmitButton'
 import { SubmitButtonHelper } from '../../SubmitButtonHelper'
 
@@ -18,28 +18,46 @@ export const RegisterMonthlyBalanceForm = () => {
 	const availableYears = getLastFiveYearsFrom(currentYear)
 	const monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
 
-	const navigate = useNavigate()
 	const [isDisabled, setIsDisabled] = useState(false)
 	const [error, setError] = useState(null)
+	const [notice, setNotice] = useState(null)
+	const noticeIdRef = useRef(0)
+	const balanceInputRef = useRef(null)
 
 	const [registerMonthlyBalance] = useMutation(REGISTER_MONTHLY_BALANCE)
 
-	const balance = useInputValue('')
+	/* Plain state instead of useInputValue: this is the only field that gets cleared on save */
+	const [balance, setBalance] = useState('')
 	const year = useInputValue(currentYear)
 	const month = useInputValue(monthNames[currentMonth])
 
+	const isValid = validateRegisterMonthlyBalanceForm(balance, year.value, month.value)
+
+	useEffect(() => {
+		if (notice) {
+			balanceInputRef.current?.focus()
+		}
+	}, [notice])
 
 	const handleSubmit = (event) => {
 		event.preventDefault()
 		setIsDisabled(true)
 		setError(null)
+		setNotice(null)
 
-		const dateToRegister = new Date(year.value, monthNames.indexOf(month.value), 1, 3)
+		const savedYear = year.value
+		const savedMonth = month.value
+		const savedBalance = parseFloat(balance)
 
-		const variables = { balance: parseFloat(balance.value), date: dateToRegister }
+		const dateToRegister = new Date(savedYear, monthNames.indexOf(savedMonth), 1, 3)
+
+		const variables = { balance: savedBalance, date: dateToRegister }
 
 		registerMonthlyBalance({ variables }).then(() => {
-			navigate('/monthly-balance/overview')
+			noticeIdRef.current += 1
+			setNotice({ id: noticeIdRef.current, message: `${savedBalance.toFixed(2)} EUR · ${savedMonth} ${savedYear}` })
+			setBalance('')
+			setIsDisabled(false)
 		}).catch(e => {
 			setError(e.message)
 			setIsDisabled(false)
@@ -50,9 +68,13 @@ export const RegisterMonthlyBalanceForm = () => {
 		<Fragment>
 			<div className="row justify-content-center mt-4">
 				<form className="col-md-8" disabled={isDisabled} onSubmit={handleSubmit}>
+
+					<SuccessToast notice={notice} />
+
 					<div className="col mb-3">
 						<label htmlFor="inputbalanceRegisterMonthlyBalanceForm" className="text-light">Balance <span className="text-danger">*</span></label>
 						<input
+							ref={balanceInputRef}
 							disabled={isDisabled}
 							inputMode="decimal"
 							className="form-control"
@@ -60,7 +82,8 @@ export const RegisterMonthlyBalanceForm = () => {
 							placeholder='1234.99'
 							type='number'
 							step='0.01'
-							{...balance}
+							value={balance}
+							onChange={(event) => setBalance(event.target.value)}
 							required
 							autoFocus
 						/>
@@ -93,8 +116,8 @@ export const RegisterMonthlyBalanceForm = () => {
 					</div>
 
 					<div className="mt-2">
-						<SubmitButton disabled={isDisabled || !validateRegisterMonthlyBalanceForm(balance.value, year.value, month.value)}>Save monthly balance</SubmitButton>
-						<SubmitButtonHelper mustShowHelper={!validateRegisterMonthlyBalanceForm(balance.value, year.value, month.value)}></SubmitButtonHelper>
+						<SubmitButton disabled={isDisabled || !isValid}>Save monthly balance</SubmitButton>
+						<SubmitButtonHelper mustShowHelper={!isValid}></SubmitButtonHelper>
 					</div>
 				</form>
 				<div className="col-md-8">

--- a/src/components/MonthlyBalance/RegisterMonthlyBalanceForm/index.test.js
+++ b/src/components/MonthlyBalance/RegisterMonthlyBalanceForm/index.test.js
@@ -38,6 +38,29 @@ const failingMutation = {
 	error: new Error('Something went wrong')
 }
 
+/* Chosen so both the year and the month differ from today's, on purpose */
+const chosenYear = 2022
+const chosenMonth = 'March'
+const firstOfChosenMonth = new Date(chosenYear, monthNames.indexOf(chosenMonth), 1, 3)
+
+const chosenMonthMutation = {
+	request: {
+		query: REGISTER_MONTHLY_BALANCE,
+		variables: { balance: 1234.99, date: firstOfChosenMonth }
+	},
+	result: {
+		data: {
+			registerMonthlyBalance: {
+				__typename: 'MonthlyBalance',
+				balance: 1234.99,
+				date: String(firstOfChosenMonth.getTime()),
+				currencyISO: 'EUR',
+				uuid: 'monthly-balance-uuid-2'
+			}
+		}
+	}
+}
+
 /* No router on purpose: if the component ever calls useNavigate again, this render throws */
 const renderForm = (mocks = [successfulMutation]) => {
 	render(
@@ -55,7 +78,19 @@ describe('RegisterMonthlyBalanceForm', () => {
 		await user.type(screen.getByLabelText(/Balance/), '1234.99')
 		await user.click(screen.getByRole('button', { name: 'Save monthly balance' }))
 
-		await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent(`✓ 1234.99 EUR · ${currentMonthName} ${currentYear}`))
+		await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent(new RegExp(`^✓ 1234\\.99 EUR · ${currentMonthName} ${currentYear}$`)))
+	})
+
+	it('reports the chosen month and year, not the current one, after a successful submission', async () => {
+		const user = userEvent.setup()
+		renderForm([chosenMonthMutation])
+
+		await user.selectOptions(screen.getByLabelText(/Year/), String(chosenYear))
+		await user.selectOptions(screen.getByLabelText(/Month/), chosenMonth)
+		await user.type(screen.getByLabelText(/Balance/), '1234.99')
+		await user.click(screen.getByRole('button', { name: 'Save monthly balance' }))
+
+		await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent(new RegExp(`^✓ 1234\\.99 EUR · ${chosenMonth} ${chosenYear}$`)))
 	})
 
 	it('clears the balance but keeps year and month after saving', async () => {
@@ -70,6 +105,7 @@ describe('RegisterMonthlyBalanceForm', () => {
 		expect(screen.getByLabelText(/Balance/)).toHaveValue(null)
 		expect(screen.getByLabelText(/Year/)).toHaveDisplayValue(String(currentYear))
 		expect(screen.getByLabelText(/Month/)).toHaveDisplayValue(currentMonthName)
+		/* Disabled because the Balance field is now empty (invalid form), not because the submission is still in flight */
 		expect(screen.getByRole('button', { name: 'Save monthly balance' })).toBeDisabled()
 	})
 

--- a/src/components/MonthlyBalance/RegisterMonthlyBalanceForm/index.test.js
+++ b/src/components/MonthlyBalance/RegisterMonthlyBalanceForm/index.test.js
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MockedProvider } from '@apollo/client/testing'
+
+import { RegisterMonthlyBalanceForm } from './index'
+import { REGISTER_MONTHLY_BALANCE } from '../../../gql/mutations/monthlyBalances'
+
+const monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+
+const currentYear = new Date().getFullYear()
+const currentMonth = new Date().getMonth()
+const currentMonthName = monthNames[currentMonth]
+
+/* The component builds the date as the 1st of the selected month at 03:00 */
+const firstOfCurrentMonth = new Date(currentYear, currentMonth, 1, 3)
+
+const successfulMutation = {
+	request: {
+		query: REGISTER_MONTHLY_BALANCE,
+		variables: { balance: 1234.99, date: firstOfCurrentMonth }
+	},
+	result: {
+		data: {
+			registerMonthlyBalance: {
+				__typename: 'MonthlyBalance',
+				balance: 1234.99,
+				date: String(firstOfCurrentMonth.getTime()),
+				currencyISO: 'EUR',
+				uuid: 'monthly-balance-uuid-1'
+			}
+		}
+	}
+}
+
+const failingMutation = {
+	...successfulMutation,
+	result: undefined,
+	error: new Error('Something went wrong')
+}
+
+/* No router on purpose: if the component ever calls useNavigate again, this render throws */
+const renderForm = (mocks = [successfulMutation]) => {
+	render(
+		<MockedProvider mocks={mocks}>
+			<RegisterMonthlyBalanceForm />
+		</MockedProvider>
+	)
+}
+
+describe('RegisterMonthlyBalanceForm', () => {
+	it('reports the saved balance and month after a successful submission', async () => {
+		const user = userEvent.setup()
+		renderForm()
+
+		await user.type(screen.getByLabelText(/Balance/), '1234.99')
+		await user.click(screen.getByRole('button', { name: 'Save monthly balance' }))
+
+		await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent(`✓ 1234.99 EUR · ${currentMonthName} ${currentYear}`))
+	})
+
+	it('clears the balance but keeps year and month after saving', async () => {
+		const user = userEvent.setup()
+		renderForm()
+
+		await user.type(screen.getByLabelText(/Balance/), '1234.99')
+		await user.click(screen.getByRole('button', { name: 'Save monthly balance' }))
+
+		await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('1234.99 EUR'))
+
+		expect(screen.getByLabelText(/Balance/)).toHaveValue(null)
+		expect(screen.getByLabelText(/Year/)).toHaveDisplayValue(String(currentYear))
+		expect(screen.getByLabelText(/Month/)).toHaveDisplayValue(currentMonthName)
+		expect(screen.getByRole('button', { name: 'Save monthly balance' })).toBeDisabled()
+	})
+
+	it('returns the focus to the balance field after saving', async () => {
+		const user = userEvent.setup()
+		renderForm()
+
+		await user.type(screen.getByLabelText(/Balance/), '1234.99')
+		await user.click(screen.getByRole('button', { name: 'Save monthly balance' }))
+
+		await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('1234.99 EUR'))
+
+		expect(screen.getByLabelText(/Balance/)).toHaveFocus()
+	})
+
+	it('keeps the value and shows the error without a toast when the mutation fails', async () => {
+		const user = userEvent.setup()
+		renderForm([failingMutation])
+
+		await user.type(screen.getByLabelText(/Balance/), '1234.99')
+		await user.click(screen.getByRole('button', { name: 'Save monthly balance' }))
+
+		expect(await screen.findByRole('alert')).toBeVisible()
+		expect(screen.getByRole('status')).toBeEmptyDOMElement()
+		expect(screen.getByLabelText(/Balance/)).toHaveValue(1234.99)
+		expect(screen.getByRole('button', { name: 'Save monthly balance' })).toBeEnabled()
+	})
+})


### PR DESCRIPTION
Saving on `/monthly-balance/add` redirected to `/monthly-balance/overview`. Adding several months in a row meant going back once per month. `/spending/add` already solved this in #240: it stays on the form and confirms the save with `SuccessToast`. This applies the same pattern to monthly balances.

## What changed

`src/components/MonthlyBalance/RegisterMonthlyBalanceForm/index.js`:

- The redirect is gone. On a successful save a toast reports what was stored — `1234.99 EUR · January 2022` — the Balance field is cleared, Year and Month keep their values, and the focus returns to Balance so the next month can be typed straight away.
- Balance moved from `useInputValue` to plain `useState`, since it is the only field that gets cleared. `useInputValue` itself is untouched on purpose: its return value is spread onto the input with `{...balance}`, so adding a setter would leak it into the DOM as an attribute, and `LoginForm` and `RegisterForm` depend on it too.
- `handleSubmit` now ignores submits on an invalid form, matching `AddExpenseForm`. Not reachable from the UI today (the button is disabled and the input is `required`), it is there for symmetry.
- Failure behaviour is unchanged: `ErrorAlert` shows, no toast, values kept.

## Tests

`RegisterMonthlyBalanceForm` had no tests. This adds five, covering the toast contents, the field reset, the focus return, a non-default month and year selection, and the failure path. Full suite is at 393 passing across 52 files.

Rendering without a router is deliberate: if `useNavigate` ever comes back, the tests throw.

## Worth knowing when reviewing

The backend still accepts two balances for the same user and month, and `parseDataForGraph` averages duplicates in silence, so the graph can show a value the user never had. The old redirect worked as an accidental brake on that. Keeping Year and Month after a save makes a duplicate easier to trigger, and this was accepted deliberately rather than mitigated in the client. The real fix is a `(user, month)` unique constraint in didibudget-backend, which is a separate repository.

Verified manually at 390px against a running backend: toast rendered correctly, URL unchanged, field cleared and focused, selects kept, toast auto-hid after 4s, console clean.
